### PR TITLE
Improve docgen type information

### DIFF
--- a/scripts/docgen/docgen.php
+++ b/scripts/docgen/docgen.php
@@ -1,7 +1,7 @@
 <?php
 /*  
   +----------------------------------------------------------------------+
-  | PHP Version 5                                                        |
+  | PHP Version 7                                                        |
   +----------------------------------------------------------------------+
   | Copyright (c) 1997-2011 The PHP Group                                |
   +----------------------------------------------------------------------+
@@ -17,7 +17,7 @@
   |             Philip Olson <philip@php.net>                            |
   +----------------------------------------------------------------------+
  
-  $Id$
+  $Id: docgen.php 336015 2015-02-27 20:31:12Z aharvey $
 */
 
 if (!(extension_loaded('reflection') && extension_loaded('pcre'))) {
@@ -202,6 +202,26 @@ function get_type_by_string($str) { /* {{{ */
 }
 /* }}} */
 
+/** @return string|null */
+function get_type_as_string(ReflectionType $type = null) { /* {{{ */
+	if ($type instanceof ReflectionNamedType) {
+		$ret = $type->getName();
+		if ($type->allowsNull()) {
+			$ret .= '|null';
+		}
+		return $ret;
+	}
+	if ($type instanceof ReflectionUnionType) {
+		$types = array_map(function($type) {return $type->getName();}, $type->getTypes());
+		return implode('|', $types);
+	}
+	if ($type instanceof ReflectionType) {
+		return (string) $type;
+	}
+	return null;
+}
+/* }}} */
+
 function create_dir($path) { /* {{{ */
 	global $OPTION;
 
@@ -223,15 +243,13 @@ function create_markup_to_params(array $params, $ident) { /* {{{ */
 	$markup = "";
 	foreach ($params as $param) {
 		/* Parameter type */
-		if (preg_match('/(\w+) \$/', (string) $param, $match)) {
-			/* 'array or NULL' is used for array type-hint */
-			$type = $match[1] == 'NULL' ? 'array' : $match[1];
-		} else {
-			$type = 'string';
+		$type = get_type_as_string($param->getType());
+		if ($type === null) {
+			$type = 'mixed';
 			if (!$param->getName()) {
 				add_warning(sprintf("Parameter name not found, param%d used", $count));
 			}
-			add_warning(sprintf("Type hint for parameter `%s' not found, 'string' used", ($param->getName() ? $param->getName() : $count)));
+			add_warning(sprintf("Type hint for parameter `%s' not found, 'mixed' used", ($param->getName() ? $param->getName() : $count)));
 		}
 
 		$markup .= sprintf("%s<methodparam%s><type>%s</type><parameter%s>%s</parameter></methodparam>". PHP_EOL,
@@ -314,6 +332,14 @@ function gen_function_markup(ReflectionFunction $function, $content) { /* {{{ */
 	/* {FUNCTION_NAME} */
 	$content = preg_replace('/\{FUNCTION_NAME\}/', $function->getName(), $content);
 
+	/* {RETURN_TYPE} */
+	$type = get_type_as_string($function->getReturnType());
+	if ($type === null) {
+		$type = 'mixed';
+		add_warning(sprintf("Return type hint for function `%s' not found, 'mixed' used", $function->getName()));
+	}
+	$content = preg_replace('/\{RETURN_TYPE\}/', "<type>$type</type>", $content, 1);
+
 	/* {FUNCTION_PARAMETERS}, {PARAMETERS_DESCRIPTION} */
 	$content = create_markup_to_parameter_section($function, $content);
 
@@ -342,7 +368,12 @@ function gen_method_markup(ReflectionMethod $method, $content) { /* {{{ */
 
 	/* {RETURN_TYPE} */
 	if (!$method->isConstructor()) {
-		$content = preg_replace('/\{RETURN_TYPE\}/', '<type>ReturnType</type>', $content, 1);
+		$type = get_type_as_string($method->getReturnType());
+		if ($type === null) {
+			$type = 'mixed';
+			add_warning(sprintf("Return type hint for method `%s' not found, 'mixed' used", $method->getName()));
+		}
+		$content = preg_replace('/\{RETURN_TYPE\}/', "<type>$type</type>", $content, 1);
 	} else {
 		$content = preg_replace('/\{RETURN_TYPE\}/', '', $content, 1);
 	}
@@ -1085,7 +1116,7 @@ foreach ($options as $opt => $value) {
 	switch ($opt) {
 		case 'v':
 		case 'version':
-			printf("%s\n", '$Revision$');
+			printf("%s\n", '$Revision: 336015 $');
 			break;
 		case 'V':
 		case 'verbose':

--- a/scripts/docgen/function.tpl
+++ b/scripts/docgen/function.tpl
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>ReturnType</type><methodname>{FUNCTION_NAME}</methodname>
+   {RETURN_TYPE}<methodname>{FUNCTION_NAME}</methodname>
    {FUNCTION_PARAMETERS}
   </methodsynopsis>
   <para>


### PR DESCRIPTION
We add support for return types and union types, and properly retrieve
the types via the `::getType()` and `::getReturnType()` methods,
repectively.