### PR TITLE
Actually add PHP 8.0 migration guide to the manual

### DIFF
--- a/manual.xml.in
+++ b/manual.xml.in
@@ -473,6 +473,7 @@
  <book xml:id="appendices">
   <title>&Appendices;</title>
   &appendices.history;
+  &appendices.migration80;
   &appendices.migration74;
   &appendices.migration73;
   &appendices.migration72;


### PR DESCRIPTION
This requires https://github.com/php/doc-en/pull/170.