### PR TITLE
chm generate batch script migrated from svn to git too!

### DIFF
--- a/build.setup_phpdoc_dir.bat
+++ b/build.setup_phpdoc_dir.bat
@@ -2,19 +2,19 @@ cd "C:\"
 mkdir phpdoc
 cd phpdoc
 mkdir logs
-svn checkout https://svn.php.net/repository/phpdoc/doc-base/trunk doc-base
-svn checkout https://svn.php.net/repository/phpdoc/en/trunk en
-svn checkout https://svn.php.net/repository/phpdoc/de/trunk de
-svn checkout https://svn.php.net/repository/phpdoc/es/trunk es
-svn checkout https://svn.php.net/repository/phpdoc/fr/trunk fr
-svn checkout https://svn.php.net/repository/phpdoc/it/trunk it
-svn checkout https://svn.php.net/repository/phpdoc/ja/trunk ja
-svn checkout https://svn.php.net/repository/phpdoc/pt_BR/trunk pt_BR
-svn checkout https://svn.php.net/repository/phpdoc/ro/trunk ro
-svn checkout https://svn.php.net/repository/phpdoc/ru/trunk ru
-svn checkout https://svn.php.net/repository/phpdoc/tr/trunk tr
-svn checkout https://svn.php.net/repository/phpdoc/kr/trunk kr
-svn checkout https://svn.php.net/repository/phpdoc/zh/trunk zh
+
+git clone https://git.php.net/repository/doc/base.git doc-base
+git clone https://git.php.net/repository/doc/en.git en
+git clone https://git.php.net/repository/doc/de.git de
+git clone https://git.php.net/repository/doc/es.git es
+git clone https://git.php.net/repository/doc/fr.git fr
+git clone https://git.php.net/repository/doc/it.git it
+git clone https://git.php.net/repository/doc/ja.git ja
+git clone https://git.php.net/repository/doc/pt_br.git pt_BR
+git clone https://git.php.net/repository/doc/ro.git ro
+git clone https://git.php.net/repository/doc/ru.git ru
+git clone https://git.php.net/repository/doc/tr.git tr
+git clone https://git.php.net/repository/doc/zh.git zh
 
 mkdir "C:\Dropbox\Dropbox\Public\chm"
 mkdir "C:\Software\"

--- a/scripts/build-chms-config.php
+++ b/scripts/build-chms-config.php
@@ -33,6 +33,7 @@
 	define('PATH_LOG', 	'C:\phpdoc\logs');
 	define('PATH_DOC', 	'C:\phpdoc');
 	define('PATH_SVN', 	'C:\Software\Subversion Client\svn.exe');
+	define('PATH_GIT', 	'C:\Software\Git\bin\git.exe');
 	define('PATH_HHC', 	'C:\Program Files (x86)\HTML Help Workshop\hhc.exe');
 	define('PATH_PHD', 	'C:\Software\PHP7.2.6\phd.bat');
  	//  Tools to build multibyte search enabled chm
@@ -63,7 +64,6 @@
 						'ro'    => 'Romanian',
 						'ru'    => 'Russian',
 						'tr'    => 'Turkish',
-						'kr'    => 'Korean',
 						'zh'    => 'Chinese (Simplified)',
 						);
 

--- a/scripts/build-chms.php
+++ b/scripts/build-chms.php
@@ -35,7 +35,7 @@
 	include_once __DIR__ .'/build-chms-config.php';
 
 	/**
-	 * The languages to build are retrieved from https://svn.php.net/repository/web/php/trunk/include/languages.inc
+	 * The languages to build are retrieved from http://git.php.net/?p=web/php.git;a=blob_plain;f=include/languages.inc;hb=HEAD
 	 */
 	if (file_exists(__DIR__ . '\\languages.inc'))
 	{
@@ -68,7 +68,7 @@
 	if(PHD_BETA)
 	{
 		chdir(dirname(PATH_PHD));
-		execute_task('Updating PhD from svn', PATH_SVN, 'up', 'phd_svn');
+		execute_task('Updating PhD from svn', PATH_GIT, 'pull', 'phd_git');
 		chdir($cwd);
 	}
 	else
@@ -81,7 +81,7 @@
 	 * entities
 	 */
 	chdir(PATH_DOC . '\\doc-base\\');
-	execute_task('Updating doc-base', PATH_SVN, 'up', 'docbase');
+	execute_task('Updating doc-base', PATH_GIT, 'pull', 'doc_base');
 	chdir($cwd);
 
 	/**
@@ -108,7 +108,7 @@
 		 * Update that specific language folder in SVN
 		 */
 		chdir(PATH_DOC . '\\' . $lang_code . '\\');
-		execute_task('- SVN', PATH_SVN, 'up', 'svn_' . $lang_code);
+		execute_task('- GIT', PATH_GIT, 'pull', 'git_' . $lang_code);
 		chdir($cwd);
 
 		/**


### PR DESCRIPTION
Finally announced abount migrating from svn to git! 
We need to migrate not only docbook related stuff, but also chm generate batch!

- changed version control command, from svn to git
- deleted inactive korean setting

Note: I tried to push this changeset to git.php.net directly, but could'nt do that because of insufficient Karma.
So, I send these changes here.