### PR TITLE
Add commit ID to build info

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -24,9 +24,8 @@
 */
 
 error_reporting(-1);
-$cvs_id = '$Id$';
 
-echo "configure.php: $cvs_id\n";
+echo "configure.php\n";
 
 function usage() // {{{
 {
@@ -229,6 +228,16 @@ function print_xml_errors($details = true) {
     }
     libxml_clear_errors();
 } // }}}
+
+function get_commit_id() {
+    global $ac;
+
+    if (is_file($file = $ac['LANGDIR'] . '/.git/refs/heads/master')) {
+        return trim(file_get_contents($file));
+    }
+
+    return '$Id$';
+}
 
 $srcdir  = dirname(__FILE__);
 $workdir = $srcdir;
@@ -505,6 +514,9 @@ if ($ac['LANGDIR'] == 'trunk') {
     $ac['EN_DIR'] = 'en';
 }
 checkvalue("yes");
+
+checking("commit ID");
+checkvalue(get_commit_id());
 
 checking("for partial build");
 checkvalue($ac['PARTIAL']);


### PR DESCRIPTION
This will help checking whether the build is actually being done with the last commit from the language repo.

For context:
After removing the [invalid IDs](https://git.php.net/?p=doc/pt_br.git;a=commitdiff;h=16c7683d767efa3953d36aed4786185bb95a3b92#patch23) to fix the pt_br build, [one of them](https://news-web.php.net/php.doc.pt-br/7044) is still referred to as cause of the issue, even when it doesn't exist anymore (nor in doc/en nor in doc/pt_br). The commit ID can be used to check whether the version being built is the correct one, helping to pinpoint the problem.