### PR TITLE
Remove spl_types from the generated manual

### DIFF
--- a/manual.xml.in
+++ b/manual.xml.in
@@ -316,7 +316,6 @@
    &reference.misc.book;
    &reference.seaslog.book;
    &reference.spl.book;
-   &reference.spl-types.book;
    &reference.stream.book;
    &reference.swoole.book;
    &reference.tidy.book;


### PR DESCRIPTION
Related to https://github.com/php/doc-en/pull/448

Other unmaintained extensions have also been removed, e.g. dc5f3f12024b6af0374e912253991660d7438480

- https://pecl.php.net/package/SPL_Types was last updated in 2012
  and is not maintained.
- SPL_Types is easy to confuse with the SPL because the same prefix is used
- SPL_Types can cause confusion because PHP has typed properties(7.4),
  and will probably also have actual enums in 8.1
  https://www.php.net/spl_types