### PR TITLE
[RFC] Updated revcheck

### DIFF
--- a/scripts/revcheck.php
+++ b/scripts/revcheck.php
@@ -672,7 +672,7 @@ HTML;
     print <<<HTML
 
  <tr class=bggray>
-  <td class="c">$en->name</td>
+  <td class="c"><a href="https://github.com/php/doc-en/blob/{$en->hash}/$key">$en->name</a></td>
   <td class="c">$en->hash</td>
   <td class="c">$size</td>
  </tr>

--- a/scripts/revcheck.php
+++ b/scripts/revcheck.php
@@ -204,9 +204,6 @@ function populateFileTreeRecurse( $lang , $path , & $output )
                 'DO_NOT_TRANSLATE',
                 'rsusi.txt',
                 'missing-ids.xml',
-                'license.xml',
-                'translation.xml',
-                'versions.xml',
             ];
             
             $ignoredDirectories = [

--- a/scripts/revcheck.php
+++ b/scripts/revcheck.php
@@ -208,8 +208,6 @@ function populateFileTreeRecurse( $lang , $path , & $output )
             
             $ignoredDirectories = [
                 'chmonly',
-                'internals',
-                'internals2',
             ];
             
             if(

--- a/scripts/revcheck.php
+++ b/scripts/revcheck.php
@@ -216,9 +216,9 @@ function populateFileTreeRecurse( $lang , $path , & $output )
                 in_array($trimPath, $ignoredDirectories, true) 
                 || in_array($filename, $ignoredFileNames, true)
                 || (strpos($filename, 'entities.') === 0)
-                || !in_array(substr($filename, -3), array('xml','ent'))
+                || !in_array(substr($filename, -3), ['xml','ent'], true)
                 || (substr($filename, -13) === 'PHPEditBackup')
-                || ($trimPath === 'appendices' && (in_array($filename, ['reserved.constants.xml', 'extensions.xml'])))
+                || ($trimPath === 'appendices' && (in_array($filename, ['reserved.constants.xml', 'extensions.xml'], true)))
             ) {
                 continue;
             }

--- a/scripts/revcheck.php
+++ b/scripts/revcheck.php
@@ -190,6 +190,42 @@ function populateFileTreeRecurse( $lang , $path , & $output )
         }
         if ( $entry->isFile() )
         {
+            $ignoredFileNames = [
+                'README.md',      
+                'translation.xml',      
+                'readme.first',      
+                'license.xml',      
+                'extensions.xml',
+                'versions.xml',
+                'book.developer.xml',
+                'contributors.ent',
+                'contributors.xml',
+                'README',
+                'DO_NOT_TRANSLATE',
+                'rsusi.txt',
+                'missing-ids.xml',
+                'license.xml',
+                'translation.xml',
+                'versions.xml',
+            ];
+            
+            $ignoredDirectories = [
+                'chmonly',
+                'internals',
+                'internals2',
+            ];
+            
+            if(
+                in_array($trimPath, $ignoredDirectories, true) 
+                || in_array($filename, $ignoredFileNames, true)
+                || (strpos($filename, 'entities.') === 0)
+                || !in_array(substr($filename, -3), array('xml','ent'))
+                || (substr($filename, -13) === 'PHPEditBackup')
+                || ($trimPath === 'appendices' && (in_array($filename, ['reserved.constants.xml', 'extensions.xml'])))
+            ) {
+                continue;
+            }
+            
             $file = new FileStatusInfo;
             $file->path = $trimPath;
             $file->name = $filename;
@@ -198,23 +234,20 @@ function populateFileTreeRecurse( $lang , $path , & $output )
             if ( $lang != 'en' )
             {
                 parseRevisionTag( $entry->getPathname() , $file );
-                if ( strlen($file->hash) == 40 and $file->size != 0  and $filename != "README.md" and $filename != "translation.xml" and $filename != "readme.first" and $filename != "license.xml" and $filename != "extensions.xml")
+                if ( strlen($file->hash) == 40 and $file->size != 0)
                 {
                     $output[ $file->getKey() ] = $file;
                 }
                 $path_en = '../en/' . $trimPath . '/' . $filename;
                 if( !is_file($path_en) )
                 {
-                    if ($filename != "README.md" and $filename != "translation.xml" and $filename != "readme.first")
-                    {
-                       $oldfile = new OldFilesInfo;
-                       $oldfile->path = $trimPath;
-                       $oldfile->name = $filename;
-                       $oldfile->size = (int)($file->size / 1024);
-                       $oldfiles[ $oldfile->getKey() ] = $oldfile;
-                    }
+                   $oldfile = new OldFilesInfo;
+                   $oldfile->path = $trimPath;
+                   $oldfile->name = $filename;
+                   $oldfile->size = (int)($file->size / 1024);
+                   $oldfiles[ $oldfile->getKey() ] = $oldfile;
                 }
-            } elseif ($trimPath !== "chmonly") {
+            } else {
                 $output[ $file->getKey() ] = $file;
             }
         }

--- a/scripts/revcheck.php
+++ b/scripts/revcheck.php
@@ -733,8 +733,8 @@ HTML;
             ." <a href='$d4' title='git.php.net html'>(h)</a>";
         if ( $en->syncStatus == FileStatusEnum::RevTagProblem )
             $nm = $en->name;
-        $h1 = "<a href='http://git.php.net/?p=doc/en.git;a=blob;f=$key;hb={$en->hash}'>{$en->hash}</a>";
-        $h2 = "<a href='http://git.php.net/?p=doc/en.git;a=blob;f=$key;hb={$tr->hash}'>{$tr->hash}</a>";
+        $h1 = "<a href='https://github.com/php/doc-en/blob/{$en->hash}/$key'>{$en->hash}</a>";
+        $h2 = "<a href='https://github.com/php/doc-en/blob/{$tr->hash}/$key'>{$tr->hash}</a>";
         $s1 = $en->size < 1024 ? 1 : floor( $en->size / 1024 );
         $s2 = $tr->size < 1024 ? 1 : floor( $tr->size / 1024 );
         $s3 = $s2 - $s1;


### PR DESCRIPTION
- Not all files should be translated, added exceptions that were applied in the [edit.php.net](https://github.com/php/web-doc-editor/blob/master/php/RepositoryManager.php#L1685). 
But I'm not sure that these rules are still actual 🤔 

- In the not translated section added the link to GitHub, where is English content for this file.

- git.php.net link on certain file revision replaced with GitHub link.