### PR TITLE
Use FilesystemIterator constants instead of `isDot`

### DIFF
--- a/scripts/qa/section-order.php
+++ b/scripts/qa/section-order.php
@@ -44,10 +44,10 @@ function checkExtension($dirname)
 {
     $fileCount = 0;
 
-    $docdir = new RecursiveDirectoryIterator($dirname);
+    $docdir = new RecursiveDirectoryIterator($dirname, FilesystemIterator::SKIP_DOTS);
 
     foreach ($docdir as $base) {
-        if ($docdir->isDot() || !$base->isDir() || !$base->isReadable()) {
+        if (!$base->isDir() || !$base->isReadable()) {
             continue;
         }
 
@@ -71,12 +71,12 @@ function checkExtension($dirname)
 
 function getXMLFiles(string $dirname)
 {
-    $directory = new RecursiveDirectoryIterator($dirname);
+    $directory = new RecursiveDirectoryIterator($dirname, FilesystemIterator::SKIP_DOTS);
 
     $files = [];
 
     foreach ($directory as $dir) {
-        if ($directory->isDot() || $dir->isDir() || !$dir->isReadable()) {
+        if ($dir->isDir() || !$dir->isReadable()) {
             continue;
         }
 


### PR DESCRIPTION
Since the reading of dotfiles files isn't something we're doing in this script, using the `FilesystemIterator::SKIP_DOTS` constant removes the use of the `isDot` check completely.  Also makes the code a bit easier to read IMHO.