### PR TITLE
Add intersection types to our docbook dtd

### DIFF
--- a/docbook/docbook-xml/docbook.dtd
+++ b/docbook/docbook-xml/docbook.dtd
@@ -2249,7 +2249,7 @@
 <!ATTLIST type
 	xmlns	CDATA	#FIXED	"http://docbook.org/ns/docbook"
 	role	CDATA	#IMPLIED
-	class	(union)	#IMPLIED
+	class	(union|intersection)	#IMPLIED
 	%db.common.attributes;
 	%db.common.linking.attributes;
 


### PR DESCRIPTION
DocBook 5.2 adds support for union and intersection types.  We already
support union types, but as of PHP 8.1.0 intersection types are
available, so we now support these as well.

Back port the syntax for intersection types to our older DocBook DTD.

Example:
`<type class="intersection"><type>Traversable</type><type>Countable</type></type>`

cc @Girgias 