### PR TITLE
Generate sources.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ install-unix.xml
 install-win.xml
 manual.xml
 version.xml
+sources.xml
 entities/file-entities.ent
 # File use to generate entities by configure script
 scripts/file-entities.php


### PR DESCRIPTION
See also php/phd#55 and php/web-php#434

The new `sources.xml` file contains the mapping from an XML ID to the source
XML file that declares it.

Generation of the `sources.xml` file is enabled by default. To disable it,
run `configure.php` with the `--disable-sources-file` option.

Example of `sources.xml` contents:

```xml
<?xml version="1.0"?>
<sources>
  <item
    id="extensions.membership"
    lang="en"
    path="appendices/extensions.xml"/>
  <item
    id="extensions.membership.core"
    lang="en"
    path="appendices/extensions.xml"/>
  ...
</sources>
```