### PR TITLE
undefined constant GLOB_BRACE on Alpine Linux

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -646,7 +646,7 @@ if ($ac['VERSION_FILES'] === 'yes') {
         }
         $globdir .= "/*/*/versions.xml";
     }
-    foreach(glob($globdir, GLOB_BRACE) as $file) {
+    foreach(glob($globdir) as $file) {
         if($tmp->load($file)) {
             foreach($tmp->getElementsByTagName("function") as $function) {
                 $function = $dom->importNode($function, true);


### PR DESCRIPTION
While following the guide on http://doc.php.net/tutorial/local-setup.php when I got to the step of running `php doc-base/configure.php` I got a warning 

```
Iterating over extension specific version files... PHP Warning:  Use of undefined constant GLOB_BRACE - assumed 'GLOB_BRACE' (this will throw an Error in a future version of PHP) in /app/doc-base/configure.php on line 649
```

While looking into it, Alpine Linux doesn't seem to support `GLOB_BRACE`.
I decided to run a container with Amazon Linux 2 (bref.sh images) and the warning does not show up there. I did the following comparison

| Distribution  | Command |
| ------------- | ------------- |
| Amazon Linux 2 | var_dump(glob($globdir)); |
| Amazon Linux 2 | var_dump(glob($globdir), GLOB_BRACE);  |
| Alpine Linux | var_dump(glob($globdir));  |

All 3 generated the exact same output. I'm not sure if I'm missing something, but simply dropping `GLOB_BRACE` seems to solve the support compatibility with Alpine without sacrificing anything?