### PR TITLE
Output entire file path

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -787,7 +787,7 @@ if ($dom->validate()) {
 CAT;
 
     if (function_exists('proc_nice') && !is_windows()) {
-        echo " (Run `nice php configure.php` next time!)\n";
+        echo " (Run `nice php $_SERVER[SCRIPT_NAME]` next time!)\n";
     }
     if ($ac["SEGFAULT_SPEED"] == "yes" && version_compare(PHP_VERSION, "5.3.7-dev", "lt")) {
         $b = basename($mxml);


### PR DESCRIPTION
`nice php configure.php` assumes that the script was executed from the root of the project. `$_SERVER[SCRIPT_NAME]` will have the entire path to `configure.php`