### PR TITLE
Add QA script to check for valid method names

### DIFF
--- a/scripts/qa/check-valid-method-names.php
+++ b/scripts/qa/check-valid-method-names.php
@@ -1,0 +1,105 @@
+<?php
+/*
+  +----------------------------------------------------------------------+
+  | PHP Version 8                                                        |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1997-2021 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.0 of the PHP license,       |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_0.txt.                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:    George Peter Banyard <girgias@php.net>                   |
+  +----------------------------------------------------------------------+
+  | Description: This file parses the manual and outputs all erroneous   |
+  |              <methodname> tag usage.                                 |
+  +----------------------------------------------------------------------+
+
+*/
+
+/* Path to the root of EN extension reference tree */
+$doc_en_root = dirname(__DIR__, 3) . '/en/reference';
+
+$total = 0;
+
+/* make a method list from files in extension directories */
+function make_method_list(string $lang_doc_root): array
+{
+    $methods = [];
+
+    foreach (new FilesystemIterator($lang_doc_root) as $extensions) {
+        if (!$extensions->isDir() || !$extensions->isReadable()) {
+            continue;
+        }
+
+        foreach (new FilesystemIterator($extensions->getPathname()) as $extension) {
+            if (!$extension->isDir() || !$extension->isReadable()) {
+                continue;
+            }
+            // Skip functions folder
+            if ($extension->getFilename() === 'functions') {
+                continue;
+            }
+
+           $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($extension->getPathname(),
+                FilesystemIterator::SKIP_DOTS | FilesystemIterator::CURRENT_AS_FILEINFO));
+
+            foreach ($it as $file) {
+                if ($file->isDir() || !$file->isReadable()) {
+                    continue;
+                }
+                $class = str_replace($extension->getPath() . '/', '', $file->getPath());
+                $class = str_replace('/', '\\', $class);
+                $method = str_replace(['-', '.'], '_', $file->getBasename('.xml'));
+                if ($method === 'construct') { $method = '__construct'; }
+                $fqn = strtolower($class . '::' . $method);
+                $methods[$fqn] = true;
+            }
+        }
+    }
+
+    return $methods;
+}
+
+echo "Building a list of methods...\n";
+$methods =  make_method_list($doc_en_root);
+
+echo 'List complete. ' . count($methods) . " methods.\n";
+
+echo "Checking the manual for <methodname> tags that contain invalid methods...\n";
+foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($doc_en_root)) as $file) {
+    if ($file->isDir() || !$file->isReadable()) {
+        continue;
+    }
+
+    $name = $file->getBasename();
+    $path = $file->getPathname();
+    $contents = file_get_contents($path);
+
+    if ($contents == '') {
+        continue;
+    }
+
+    if (preg_match_all('|<methodname>(.*?)</methodname>|s', $contents, $m)
+        && is_array($m)
+        && is_array($m[1]))
+    {
+        foreach ($m[1] as $method) {
+            $method = strtolower(trim($method));
+
+            if (!\array_key_exists($method, $methods)) {
+                $total++;
+                $fileout = substr($file, strlen($doc_en_root) + 1);
+
+                printf("%-60.60s  <methodname>$method</methodname>\n", $fileout);
+            }
+        }
+    }
+}
+echo "Found $total occurrences.\n";
+
+exit((bool) $total);


### PR DESCRIPTION
This is based on ``scripts/qa/check-valid-function.php``.

However, I've walked into a conundrum because it turns out all functions use the ``<methodsynopsis>`` tag instead of ``<funcsynopsis>`` meaning that for the prototype of every function there is a usage of ``<methodname>`` which is currently being flagged.

I'm not totally sure what's the best way to approach this is in the script (because changing half the docs to be semantically correct, although nice, is not practical). So if anyone has ideas.