### PR TITLE
Add a link entity for PHP source code reference

### DIFF
--- a/entities/global.ent
+++ b/entities/global.ent
@@ -367,6 +367,8 @@
 <!ENTITY url.php.release4.2.0 "https://www.php.net/releases/4_2_0.php">
 <!ENTITY url.php.svn "https://svn.php.net/">
 <!ENTITY url.php.git.phpini "https://github.com/php/php-src/blob/master/php.ini-production">
+<!-- linking to specific source file is done like so: &url.php.git.src.master.view;file_path -->
+<!ENTITY url.php.git.src.master.view "https://github.com/php/php-src/blob/master/">
 <!ENTITY url.php.talks 'http://talks.php.net/'>
 <!ENTITY url.php.support "https://www.php.net/support.php">
 <!ENTITY url.php.urlhowto "https://www.php.net/urlhowto.php">


### PR DESCRIPTION
PHP manual has a few cases referring to PHP source code file, and
therefore add an external link entity to be used for this purpose.

Signed-off-by: Su, Tao <tao.su@intel.com>