### PR TITLE
Run QA scripts which are run on the EN docs

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -52,5 +52,11 @@ jobs:
           path: "en"
           repository: "php/doc-en"
 
+      - name: "Run QA scripts for EN docs"
+        if: "matrix.language == 'en'"
+        run: |
+          php8.0 doc-base/scripts/qa/extensions.xml.php --check
+          php8.0 doc-base/scripts/qa/section-order.php
+
       - name: "Build documentation for ${{ matrix.language }}"
         run: "php8.0 doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"

--- a/scripts/qa/extensions.xml.php
+++ b/scripts/qa/extensions.xml.php
@@ -154,18 +154,23 @@ if ($checkFile) {
     echo "{$basedir}/en/appendices/extensions.xml has been updated, check it for details\n";
 }
 
+$status = 0;
 // print the debug messages:
 if (isset($debug['membership'])) {
 	echo "\nExtensions Missing Membership:\n";
+	$status = 2;
 	print_r($debug['membership']);
 }
 
 if (isset($debug['bogus-membership'])) {
 	echo "\nExtensions with bogus Membership:\n";
+	$status = 2;
 	print_r($debug['bogus-membership']);
 }
 
 if (isset($debug['unknown-extension'])) {
 	echo "\nExtensions with unknown extension title:\n";
+	$status = 2;
 	print_r($debug['unknown-extension']);
 }
+exit($status);


### PR DESCRIPTION
If a change to the QA scripts are made we can at least see if this going to make the EN build fail before a push is made on the docs