### PR TITLE
Properly skip SKIP_FILEs on Windows

### DIFF
--- a/scripts/qa/section-order.php
+++ b/scripts/qa/section-order.php
@@ -132,7 +132,7 @@ function getXMLFiles(string $dirname)
         }
 
         /* Skip certain files */
-        $pathnameFromRoot = str_replace(DOCROOT_EN, '', $dir->getPathname());
+        $pathnameFromRoot = str_replace([DOCROOT_EN, '\\'], ['', '/'], $dir->getPathname());
         if (in_array($pathnameFromRoot, SKIP_FILE)) {
             continue;
         }


### PR DESCRIPTION
Without this patch:

````
D:\git\php\phpdoc>php doc-base\scripts\qa\section-order.php
File D:\git\php\phpdoc/en/reference\filesystem/functions\delete.xml No parameters sections.
File D:\git\php\phpdoc/en/reference\filesystem/functions\delete.xml No returnvalues sections.
File D:\git\php\phpdoc/en/reference\misc/functions\die.xml No parameters sections.
File D:\git\php\phpdoc/en/reference\misc/functions\die.xml No returnvalues sections.
File D:\git\php\phpdoc/en/reference\oci8/oldaliases\ocifetchinto.xml No parameters sections.
File D:\git\php\phpdoc/en/reference\oci8/oldaliases\ocifetchinto.xml No returnvalues sections.
File D:\git\php\phpdoc/en/reference\parallel/functions\parallel.run.xml Invalid section role: 'scheduling-characteristics'.
File D:\git\php\phpdoc/en/reference\parallel/functions\parallel.run.xml No parameters sections.
File D:\git\php\phpdoc/en/reference\parallel/functions\parallel.run.xml No returnvalues sections.
````

@Girgias, what do you think?