### PR TITLE
Add missing entity

### DIFF
--- a/entities/global.ent
+++ b/entities/global.ent
@@ -155,6 +155,7 @@
 <!ENTITY url.iis.fastcgi.downloads "http://www.iis.net/extensions/fastcgi">
 <!ENTITY url.iis.fastcgi.settings "http://learn.iis.net/page.aspx/248/configuring-fastcgi-extension-for-iis-60/">
 <!ENTITY url.imagemagick "http://www.imagemagick.org/">
+<!ENTITY url.imagemagick.usage.color_mods.sigmoidal "http://www.imagemagick.org/Usage/color_mods/#sigmoidal">
 <!ENTITY url.imagemagick.usage.transform.function "http://www.imagemagick.org/Usage/transform/#function">
 <!ENTITY url.imap "https://github.com/uw-imap/imap">
 <!ENTITY url.imap.book "http://oreilly.com/catalog/9780596000127/">


### PR DESCRIPTION
This entity was removed on 18f17b8 due to being wrongly marked as obsolete in b2bc755. The reason for it being marked as obsolete may be due to a missing `&` character to reference the URL, introduced in https://github.com/php/doc-en/commit/f1e61c544919763580fbcaac3c618db3ccdde0dd