### PR TITLE
Use available php for GH CI

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -55,8 +55,8 @@ jobs:
       - name: "Run QA scripts for EN docs"
         if: "matrix.language == 'en'"
         run: |
-          php8.0 doc-base/scripts/qa/extensions.xml.php --check
-          php8.0 doc-base/scripts/qa/section-order.php
+          php doc-base/scripts/qa/extensions.xml.php --check
+          php doc-base/scripts/qa/section-order.php
 
       - name: "Build documentation for ${{ matrix.language }}"
-        run: "php8.0 doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"
+        run: "php doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"


### PR DESCRIPTION
Hard-coding a certain php version doesn't make sense if we use ubuntu- *latest*.  Either we use the default php (as with this patch), or we commit to a certain Ubuntu version.

---

cc @mumumu, @localheinz 