### PR TITLE
Let build fail for erroneous xincludes

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -715,8 +715,10 @@ echo "done.\n";
 echo "Validating {$ac["INPUT_FILENAME"]}... ";
 flush();
 
-$dom->xinclude();
-print_xml_errors();
+if ($dom->xinclude() === -1) {
+    print_xml_errors();
+    errors_are_bad(1);
+}
 
 if ($ac['PARTIAL'] != '' && $ac['PARTIAL'] != 'no') { // {{{
     $dom->validate(); // we don't care if the validation works or not


### PR DESCRIPTION
So far, these errors have been reported, but didn't cause the build to fail, so were easily overlooked[1].

[1] <https://github.com/php/doc-en/commit/89eaa41302bd5a9c7f66640446eefde6061649a4#r92913331>