### PR TITLE
Update url.ip2long.tech

### DIFF
--- a/entities/global.ent
+++ b/entities/global.ent
@@ -168,7 +168,7 @@
 <!ENTITY url.ingres.wiki "http://community.ingres.com/wiki/">
 <!ENTITY url.installkits "http://wikipedia.org/wiki/List_of_AMP_packages">
 <!ENTITY url.iodbc "http://www.iodbc.org/">
-<!ENTITY url.ip2long.tech "http://publibn.boulder.ibm.com/doc_link/en_US/a_doc_lib/libs/commtrf2/inet_addr.htm">
+<!ENTITY url.ip2long.tech "http://ps-2.kev009.com/wisclibrary/aix52/usr/share/man/info/en_US/a_doc_lib/libs/commtrf2/inet_addr.htm">
 <!ENTITY url.iptc "http://www.iptc.org/">
 <!ENTITY url.iso-639 "http://www.loc.gov/standards/iso639-2/php/code_list.php">
 <!ENTITY url.iso-8601.duration "http://en.wikipedia.org/wiki/Iso8601#Durations">


### PR DESCRIPTION
The old url is gone. The new url has equivalent content, though from a newer version of the source material.

Wayback machine link to old content: https://web.archive.org/web/20220108175123/http://publibn.boulder.ibm.com/doc_link/en_US/a_doc_lib/libs/commtrf2/inet_addr.htm

Fixes https://github.com/php/doc-en/issues/2168