### PR TITLE
Update config for `xmllint` at `xml-check.php`

### DIFF
--- a/scripts/xml-check.php
+++ b/scripts/xml-check.php
@@ -43,7 +43,7 @@ $fp = fopen($example_filename, "wb");
 fwrite($fp, $file);
 fclose($fp);
 
-passthru("$xmllint --noent --noout --valid $example_filename 2> $example_filename.out"); // xmllint outputs to stderr which is not catched by shell_exec, 2> &1 doesn't work on Windows
+passthru("XMLLINT_INDENT=' ' $xmllint --noent --noout --encode UTF-8 --format --valid $example_filename 2> $example_filename.out"); // xmllint outputs to stderr which is not catched by shell_exec, 2> &1 doesn't work on Windows
 $errors = file_get_contents("$example_filename.out");
 $errors = preg_replace("~.*validity error : IDREF attribute linkend references an unknown ID.*\n.*\n.*\n~", "", $errors);
 $errors = str_replace($example_filename, $_SERVER["argv"][1], $errors);


### PR DESCRIPTION
The XML files in the docs are using 1 space for indentation, so setting the `XMLLINT_INDENT= ' '` environment variable and the `--format` option for `xmllint` ensuring the right indentation makes sense to me.
Regarding the encoding, [some files](https://github.com/php/doc-base/blob/140b2f686197c7100f5126a7e2ac16fb096ab309/funcindex.xml#L1) are using `UTF-8`, [others](https://github.com/php/doc-en/blob/cb010c77b6a2f0b35218cd1663cb8f5b88035069/reference/ibm_db2/configure.xml#L1) `utf-8`.

See: https://gnome.pages.gitlab.gnome.org/libxml2/xmllint.html