### PR TITLE
Add file modification history update script

### DIFF
--- a/scripts/updateModHistory.php
+++ b/scripts/updateModHistory.php
@@ -182,7 +182,8 @@ function processGitDiffLine($line, &$modifiedFiles): void {
 }
 
 function verifyCommandLineOptions($commandLineOptions): void {
-    echo timeStamp() . " - Parsing command line arguments... ";
+    $output = timeStamp() . " - Parsing command line arguments... ";
+    echo $output;
     if ($commandLineOptions === false
         || !isset($commandLineOptions["docs-path"])) {
         echo "\"--docs-path\" is a required argument\n";
@@ -190,10 +191,11 @@ function verifyCommandLineOptions($commandLineOptions): void {
     }
     echo "documentation path supplied\n";
     if (isset($commandLineOptions["history-path"])) {
-        echo "                                               mod history file path supplied\n";
+        echo str_repeat(" ", strlen($output)) . "mod history file path supplied\n";
     }
 
-    echo timeStamp() . " - Verifying command line arguments... ";
+    $output = timeStamp() . " - Verifying command line arguments... ";
+    echo $output;
     if (!file_exists($commandLineOptions["docs-path"])) {
         echo "documentation path \"" . $commandLineOptions["docs-path"] . "\" doesn't exist\n";
         exit(1);
@@ -201,17 +203,17 @@ function verifyCommandLineOptions($commandLineOptions): void {
         echo "documentation path \"" . $commandLineOptions["docs-path"] . "\" is not a directory\n";
         exit(1);
     }
-    echo "documentation path verified";
+    echo "documentation path verified\n";
 
     if (isset($commandLineOptions["history-path"])) {
+        echo "\n" . str_repeat(" ", strlen($output)) . "mod history file path ";
         if (!file_exists($commandLineOptions["history-path"])) {
-            echo "\n                                                 mod history file path \"" . $commandLineOptions["history-path"] . "\" doesn't exist\n";
+            echo "\"" . $commandLineOptions["history-path"] . "\" doesn't exist\n";
             exit(1);
         } else if (!is_file($commandLineOptions["history-path"])) {
-            echo "\n                                                 mod history file path \"" . $commandLineOptions["history-path"] . "\" is not a file\n";
+            echo "\"" . $commandLineOptions["history-path"] . "\" is not a file\n";
             exit(1);
         }
-        echo "\n                                                 mod history file path verified";
+        echo "verified\n";
     }
-    echo "\n";
 }

--- a/scripts/updateModHistory.php
+++ b/scripts/updateModHistory.php
@@ -191,7 +191,7 @@ function verifyCommandLineOptions($commandLineOptions): void {
     }
     echo "documentation path supplied\n";
     if (isset($commandLineOptions["history-path"])) {
-        echo str_repeat(" ", strlen($output)) . "mod history file path supplied\n";
+        printf("%*smod history file path supplied\n", strlen($output), " ");
     }
 
     $output = timeStamp() . " - Verifying command line arguments... ";
@@ -206,7 +206,7 @@ function verifyCommandLineOptions($commandLineOptions): void {
     echo "documentation path verified\n";
 
     if (isset($commandLineOptions["history-path"])) {
-        echo "\n" . str_repeat(" ", strlen($output)) . "mod history file path ";
+        printf("\n%*smod history file path ", strlen($output), " ");
         if (!file_exists($commandLineOptions["history-path"])) {
             echo "\"" . $commandLineOptions["history-path"] . "\" doesn't exist\n";
             exit(1);

--- a/scripts/updateModHistory.php
+++ b/scripts/updateModHistory.php
@@ -78,13 +78,13 @@ COMMAND;
 
 echo timeStamp() . " - Retrieving commit authors and last commit date/time of modified files... \n";
 
-$fileCounter = 0;
 $modifiedFiles = [];
 
 $proc = popen($modifiedFilescommand, 'rb');
 while (($line = fgets($proc)) !== false) {
     processGitDiffLine(rtrim($line, "\n\r"), $modifiedFiles);
     if (! $runningInGithubActions) {
+        $fileCounter = max(count($modifiedFiles) - 1, 0);
         fwrite(
             STDERR,
             sprintf("\033[0G{$fileCounter} of {$numOfFilesWithDiff} files read...", "", "")
@@ -140,12 +140,10 @@ function timeStamp(): string {
 function processGitDiffLine($line, &$modifiedFiles): void {
     static $currentType = "";
     static $currentFile = "";
-    global $fileCounter;
 
     switch ($line) {
         case "filename:":
             $currentType = "filename";
-            $fileCounter++;
             return;
         case "modified:":
             $currentType = "modDateTime";

--- a/scripts/updateModHistory.php
+++ b/scripts/updateModHistory.php
@@ -1,0 +1,123 @@
+<?php
+
+$modHistoryFile = 'fileModHistory.php';
+
+$modHistoryArray = [];
+if (file_exists($modHistoryFile)) {
+    $modHistoryArray = include $modHistoryFile;
+    if (!is_array($modHistoryArray)) {
+        exit("Corrupted modificiation history file\n");
+    }
+}
+
+if (isset($modHistoryArray["last commit hash"]) && $modHistoryArray["last commit hash"] !== "") {
+    $cmd = "git rev-parse --quiet --verify " . $modHistoryArray["last commit hash"];
+    if (exec($cmd, $verifiedHash) === false) {
+        exit("Could not retrieve hash of the last commit\n");
+    }
+    if (implode("", $verifiedHash) !== $modHistoryArray["last commit hash"]) {
+        // we cannot handle reverted commits as we don't know what changes to roll back
+        exit("Modification history file's commit hash is not in this branch's commit history\n");
+    }
+    $lastCommitHash = $modHistoryArray["last commit hash"];
+} else {
+    // since there is no modification history, generate it for all commits since the inital one
+    // 4b825dc642cb6eb9a060e54bf8d69288fbee4904 is the SHA1 of the empty git tree
+    $lastCommitHash = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+}
+
+$modifiedFilescommand = <<<COMMAND
+#!/usr/bin/env bash
+echo "last commit hash:"
+echo "$(git rev-parse HEAD)"
+git diff --name-only HEAD $lastCommitHash | while read -r filename; do
+  echo "filename:"
+  echo "\$filename"
+  echo "modified:"
+  echo "$(git log -1 --format='%aI' -- \$filename)"
+  echo "contributors:"
+  git log --format='%an' -- \$filename|awk '!a[$0]++'
+done
+COMMAND;
+
+if (exec($modifiedFilescommand, $output) === false) {
+    exit("Could not retrieve info from last commit\n");
+}
+
+$modifiedFiles = [];
+$currentType = "";
+foreach ($output as $line) {
+    switch ($line) {
+        case "filename:":
+            $currentType = "filename";
+            continue 2;
+        case "modified:":
+            $currentType = "modDateTime";
+            continue 2;
+        case "contributors:":
+            $currentType = "contributors";
+            continue 2;
+        case "last commit hash:":
+            $currentType = "commitHash";
+            continue 2;
+    }
+    if ($currentType === "") {
+        continue;
+    }
+
+    switch ($currentType) {
+        case "filename":
+            $currentFile = $line;
+            break;
+        case "modDateTime":
+            if ($currentFile === "") {
+                continue 2;
+            }
+            $modifiedFiles[$currentFile]["modified"] = $line;
+            break;
+        case "contributors":
+            if ($currentFile === "") {
+                continue 2;
+            }
+            $modifiedFiles[$currentFile]["contributors"][] = htmlspecialchars($line, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
+            break;
+        case "commitHash":
+            $modifiedFiles["last commit hash"][] = $line;
+            break;
+    }
+}
+
+if (count($modifiedFiles) === 1) {
+    // there will always be 1 entry with the last commit hash
+    exit("No files have been modified\n");
+}
+
+$mergedModHistory = array_merge($modHistoryArray, $modifiedFiles);
+
+$newModHistoryString = "<?php\n\n/* This is a generated file */\n\nreturn [\n";
+foreach ($mergedModHistory as $fileName => $fileProps) {
+    if ($fileName === "last commit hash") {
+        $newModHistoryString .= "    \"last commit hash\" => \"" . implode("", $fileProps) . "\",\n";
+        continue;
+    }
+    $newModHistoryString .= '    "' . $fileName . "\" => [\n";
+    $newModHistoryString .= "        \"modified\" => \"" . ($fileProps["modified"] ?? "") . "\",\n";
+    $newModHistoryString .= "        \"contributors\" => [\n";
+    if (isset($fileProps["contributors"])) {
+        if (!is_array($fileProps["contributors"])) {
+            exit("Non-array contributors list\n");
+        }
+        foreach ($fileProps["contributors"] as $contributor) {
+            $newModHistoryString .= "            \"" . $contributor . "\",\n";
+        }
+    }
+    $newModHistoryString .= "        ],\n";
+    $newModHistoryString .= "    ],\n";
+}
+$newModHistoryString .= "];\n";
+
+if (file_put_contents($modHistoryFile, $newModHistoryString) === false) {
+    exit("Could not write modification history file\n");
+}
+
+echo "Modification history updated\n";


### PR DESCRIPTION
Add file modification history update script. This script can be used to update the `fileModHistory.php` files in the documentation repos which contain the last modification date/time and the contributor list for every file in the repo.

The ideal way to use this script would be something like a pre-commit hook which would generate the update to the history file, and be merged and potentially reverted together with its parent commit. If anyone knows how to do this on GitHub, please let me know.