### PR TITLE
Relax <reference> tag DTD

### DIFF
--- a/docbook/docbook-xml/docbook.dtd
+++ b/docbook/docbook-xml/docbook.dtd
@@ -2737,7 +2737,7 @@
 
 >
 
-<!ELEMENT reference (((title|titleabbrev|subtitle)*, info?), partintro?, (refentry)+)>
+<!ELEMENT reference (((title|titleabbrev|subtitle)*, info?), partintro?, (refentry)*)>
 
 <!ATTLIST reference
 	xmlns	CDATA	#FIXED	"http://docbook.org/ns/docbook"


### PR DESCRIPTION
DocBook 5.1 and 5.2 allow "Zero or more of" `<refentry>`, whereas DocBook 5.0 and below required "One or more of" `<refentry>`

cf. https://tdg.docbook.org/tdg/5.2/reference