### PR TITLE
Change <classsynopsis> DocBook 5.2 RelaxNG schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ DocBook on Linux or Windows, or what conventions you
 should follow when writing phpdoc files, please refer
 to the PHP Documentation HOWTO.
 
+The PHP Documentation uses the [DocBook 5.2](https://tdg.docbook.org/tdg/5.2/) XML schema. \
+However, there is one small change between the official Docbook 5.2 schema and the schema used by the PHP documentation:
+the `<classsynopsis>` tag allows "One or more Oriented Object Programming inlines",
+like the [DocBook 5.1](https://tdg.docbook.org/tdg/5.1/classsynopsis) schema does,
+instead of "One Oriented Object Programming inlines".
+
 You can read the HOWTO online at: http://doc.php.net/tutorial/
 
 If you are already working with the phpdoc module,

--- a/docbook/docbook-v5.2-os/rng/docbook.rng
+++ b/docbook/docbook-v5.2-os/rng/docbook.rng
@@ -16249,7 +16249,9 @@ where the nonterminal
         <zeroOrMore>
           <ref name="db.templatename"/>
         </zeroOrMore>
-        <ref name="db.oo.inlines"/>
+        <oneOrMore>
+          <ref name="db.oo.inlines"/>
+        </oneOrMore>
         <zeroOrMore>
           <choice>
             <ref name="db.template"/>

--- a/docbook/docbook-v5.2-os/rng/docbookxi.rng
+++ b/docbook/docbook-v5.2-os/rng/docbookxi.rng
@@ -16394,7 +16394,9 @@ where the nonterminal
         <zeroOrMore>
           <ref name="db.templatename"/>
         </zeroOrMore>
-        <ref name="db.oo.inlines"/>
+        <oneOrMore>
+          <ref name="db.oo.inlines"/>
+        </oneOrMore>
         <zeroOrMore>
           <choice>
             <ref name="db.template"/>


### PR DESCRIPTION
DocBook 5.2 has made it more restrictive than DocBook 5.1, so we revert this change locally until we hear back from the OASIS OPEN DocBook committee.

This change is required as the PHP documentation does use multiple OOP inline tags in a `<classsynopsis>`.