### PR TITLE
Remove empty PHP Manual page

### DIFF
--- a/manual.xml.in
+++ b/manual.xml.in
@@ -41,7 +41,7 @@
  <title>&PHPManual;</title>
  &bookinfo;
 
- <book xml:id="manual">
+ <book xml:id="manual" annotations="chunk:false">
   <title>&PHPManual;</title>
   &preface;
  </book>


### PR DESCRIPTION
This PR replaces the below empty "PHP Manual" [page](https://www.php.net/manual/en/manual.php) with the Preface page that it is linking to.
