### PR TITLE
Remove XForms from the manual (part of php/doc-en#3579)

### DIFF
--- a/manual.xml.in
+++ b/manual.xml.in
@@ -112,7 +112,6 @@
   &features.http-auth;
   &features.cookies;
   &features.sessions;
-  &features.xforms;
   &features.file-upload;
   &features.remote-files;
   &features.connection-handling;


### PR DESCRIPTION
The XForms content will also need to be removed from each of the `doc-$LANG` repos.