### PR TITLE
Convert MongoDB from set to book

### DIFF
--- a/manual.xml.in
+++ b/manual.xml.in
@@ -205,7 +205,7 @@
     &reference.dbase.book;
     &reference.ibase.book;
     &reference.ibm-db2.book;
-    &reference.mongodb.set;
+    &reference.mongodb.book;
     &reference.mysqlinfo.set;
     &reference.oci8.book;
     &reference.pgsql.book;


### PR DESCRIPTION
This is the `doc-base` part of converting the MongoDB extension from a `<set>` to a `<book>` as its top level element. 

Please note that for this PR to work documentation repositories will need to make the same changes as in the accompanying `doc-en` [PR](https://github.com/php/doc-en/pull/3627).