### PR TITLE
Only include per-function changelog since 7.0.0, not 5.0.0

### DIFF
--- a/manual.xml.in
+++ b/manual.xml.in
@@ -462,7 +462,7 @@
   <appendix xmlns="http://docbook.org/ns/docbook" xml:id="doc.changelog">
    <title>&ChangelogListingTitle;</title>
     <para>&ChangelogListingBundledDescription;</para>
-    <?phpdoc changelog-config-since="5.0.0" ?>
+    <?phpdoc changelog-config-since="7.0.0" ?>
     <?phpdoc generate-changelog-for-membership="core bundled bundledexternal" ?>
    </appendix>
  </book>


### PR DESCRIPTION
Related to php/phd#16, which fixes the changelog generation.