### PR TITLE
Update xmlsoft.org URLs to gitlab.gnome.org

### DIFF
--- a/entities/global.ent
+++ b/entities/global.ent
@@ -84,7 +84,7 @@
 <!ENTITY url.expat "https://libexpat.github.io/">
 <!ENTITY url.expat.rpm "https://sourceforge.net/projects/expat/">
 <!ENTITY url.expect "http://expect.nist.gov/">
-<!ENTITY url.exsltlib "http://xmlsoft.org/XSLT/EXSLT/index.html">
+<!ENTITY url.exsltlib "https://gitlab.gnome.org/GNOME/libxslt/-/wikis/home">
 <!ENTITY url.ezweb "http://www.au.kddi.com/english/service/ezweb/index.html">
 <!ENTITY url.fann.lib "http://leenissen.dk/fann/wp/">
 <!ENTITY url.fann.github "https://github.com/bukka/php-fann">
@@ -190,9 +190,9 @@
 <!ENTITY url.libiconv "http://www.gnu.org/software/libiconv/">
 <!ENTITY url.liblzf "http://oldhome.schmorp.de/marc/liblzf.html">
 <!ENTITY url.libsodium "https://libsodium.org/">
-<!ENTITY url.libxml "http://www.xmlsoft.org/">
-<!ENTITY url.libxml.errorcodes "http://www.xmlsoft.org/html/libxml-xmlerror.html">
-<!ENTITY url.libxslt "http://xmlsoft.org/XSLT/">
+<!ENTITY url.libxml "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home">
+<!ENTITY url.libxml.errorcodes "https://gnome.pages.gitlab.gnome.org/libxml2/devhelp/libxml2-xmlerror.html">
+<!ENTITY url.libxslt "https://gitlab.gnome.org/GNOME/libxslt/-/wikis/home">
 <!ENTITY url.libssh2 "http://libssh2.org/">
 <!ENTITY url.libpng "http://www.libpng.org/pub/png/libpng.html">
 <!ENTITY url.libradius "http://www.freebsd.org/cgi/man.cgi?query=libradius">


### PR DESCRIPTION
The old Website is still HTTP only, but redirects to the new Website; this may not work without issues, though.

Closes GH-153.