### PR TITLE
Remove the Installation problems chapter

### DIFF
--- a/manual.xml.in
+++ b/manual.xml.in
@@ -61,7 +61,6 @@
   &install.cloud.index;
   &install.fpm.index;
   &install.pecl;
-  &install.problems;
   &install.ini;
  </book>
 


### PR DESCRIPTION
References should link to faq.installation instead (related to php/doc-en#3785)