### PR TITLE
Add PI processing support for common phrases

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -797,6 +797,34 @@ if ( $ac['XPOINTER_REPORTING'] == 'yes' || $ac['LANG'] == 'en' )
     }
 }
 
+echo "Process PI nodes...\n";
+if (!$ac['LANG'] == 'en') {
+    if (file_exists($srcdir . '/pi_processing/langs/' . $ac['LANG'] . '.php')) {
+        require_once $srcdir . '/pi_processing/langs/' . $ac['LANG'] . '.php';
+    }
+}
+require_once $srcdir . '/pi_processing/langs/en.php';
+require_once $srcdir . '/pi_processing/processors.php';
+$xpath = new DOMXPath($dom);
+foreach ($xpath->query('//processing-instruction()') as $pi) {
+    if (!str_starts_with($pi->target, 'phpdoc')) {
+        continue;
+    }
+    // Don't care about generic phpdoc PI target
+    if ($pi->target === 'phpdoc') {
+        continue;
+    }
+
+    var_dump($pi->target, $pi->data);
+    $fn = match ($pi->target) {
+        'phpdoc_error_ValueError_between' => error_section_value_error_between(...),
+        'phpdoc_error_ValueError_between_changelog' => error_section_value_error_between_changelog(...),
+    };
+    $data = explode(' ', $pi->data);
+    $node = $fn($dom, ...$data);
+    $pi->parentNode->insertBefore($node, $pi);
+}
+
 echo "Validating {$ac["INPUT_FILENAME"]}... ";
 flush();
 if ($ac['PARTIAL'] != '' && $ac['PARTIAL'] != 'no') { // {{{

--- a/pi_processing/langs/en.php
+++ b/pi_processing/langs/en.php
@@ -1,0 +1,25 @@
+<?php
+
+if (!defined('VALUE_ERROR_BETWEEN_ERROR_SECTION')) {
+    define('VALUE_ERROR_BETWEEN_ERROR_SECTION', <<<'CONTENT'
+<simpara xmlns="http://docbook.org/ns/docbook">
+ Throws a <exceptionname>ValueError</exceptionname> if <parameter>PARAMETER_NAME</parameter>
+ is less than MIN_TAG or greater than MAX_TAG.
+</simpara>
+CONTENT
+    );
+}
+
+if (!defined('VALUE_ERROR_BETWEEN_CHANGELOG')) {
+    define('VALUE_ERROR_BETWEEN_CHANGELOG', <<<'CONTENT'
+<row xmlns="http://docbook.org/ns/docbook">
+ <entry>VERSION</entry>
+ <entry>
+  A <exceptionname>ValueError</exceptionname> is now thrown if
+  <parameter>PARAMETER_NAME</parameter> is less than MIN_TAG
+  or greater than MAX_TAG
+ </entry>
+</row>
+CONTENT
+    );
+}

--- a/pi_processing/langs/fr.php
+++ b/pi_processing/langs/fr.php
@@ -1,0 +1,18 @@
+<?php
+
+const VALUE_ERROR_BETWEEN_ERROR_SECTION = <<<'CONTENT'
+<simpara>
+ Lance une <exceptionname>ValueError</exceptionname> si <parameter>PARAMETER_NAME</parameter>
+ est moins que MIN_TAG ou plus grand que MAX_TAG.
+</simpara>
+CONTENT;
+
+const VALUE_ERROR_BETWEEN_CHANGELOG = <<<'CONTENT'
+<row>
+ <entry>VERSION</entry>
+ <entry>
+  Une <exceptionname>ValueError</exceptionname> est désormais lancé si
+  <parameter>PARAMETER_NAME</parameter> est moins que MIN_TAG ou plus grand que MAX_TAG
+ </entry>
+</row>
+CONTENT;

--- a/pi_processing/processors.php
+++ b/pi_processing/processors.php
@@ -1,0 +1,46 @@
+<?php
+
+function error_section_value_error_between(
+    DOMDocument $dom,
+    string $parameter,
+    string $min,
+    string $max
+): DOMElement {
+    $min_tag_name = is_numeric($min) ? 'literal' : 'constant';
+    $max_tag_name = is_numeric($max) ? 'literal' : 'constant';
+
+    $min_tag = '<' . $min_tag_name . '>' . $min . '</' . $min_tag_name . '>';
+    $max_tag = '<' . $max_tag_name . '>' . $max . '</' . $max_tag_name . '>';
+
+    $xml = str_replace(
+        ['PARAMETER_NAME', 'MIN_TAG', 'MAX_TAG'],
+        [$parameter, $min_tag, $max_tag],
+        VALUE_ERROR_BETWEEN_ERROR_SECTION,
+    );
+    $localDom = new DOMDocument();
+    $localDom->loadXML($xml);
+    return $dom->importNode($localDom->documentElement, true);
+}
+
+function error_section_value_error_between_changelog(
+    DOMDocument $dom,
+    string $version,
+    string $parameter,
+    string $min,
+    string $max
+): DOMElement {
+    $min_tag_name = is_numeric($min) ? 'literal' : 'constant';
+    $max_tag_name = is_numeric($max) ? 'literal' : 'constant';
+
+    $min_tag = '<' . $min_tag_name . '>' . $min . '</' . $min_tag_name . '>';
+    $max_tag = '<' . $max_tag_name . '>' . $max . '</' . $max_tag_name . '>';
+
+    $xml = str_replace(
+        ['VERSION', 'PARAMETER_NAME', 'MIN_TAG', 'MAX_TAG'],
+        [$version, $parameter, $min_tag, $max_tag],
+        VALUE_ERROR_BETWEEN_CHANGELOG,
+    );
+    $localDom = new DOMDocument();
+    $localDom->loadXML($xml);
+    return $dom->importNode($localDom->documentElement, true);
+}


### PR DESCRIPTION
Initial support for generic sentences via PI instead of forcing translations (and English docs) to write the same thing over and over again, also improves consistency.

See: https://github.com/php/doc-en/pull/3965