### PR TITLE
fix: Add hasAttributes check in XML attribute extraction

### DIFF
--- a/scripts/translation/qaxml.a.php
+++ b/scripts/translation/qaxml.a.php
@@ -74,11 +74,24 @@ foreach ( $qalist as $qafile )
         print "\n";
 }
 
-function extractTriple( array $list )
+function extractTriple(array $list)
 {
     $ret = array();
-    foreach( $list as $elem )
-        foreach( $elem->attributes as $attrib )
-            $ret[] = "{$elem->nodeName} {$attrib->nodeName} {$attrib->nodeValue}";
+    try {
+        foreach ($list as $elem) {
+            if ($elem->hasAttributes()) {
+                foreach ($elem->attributes as $attrib) {
+                    $ret[] = sprintf(
+                        "%s %s %s",
+                        $elem->nodeName,
+                        $attrib->nodeName,
+                        $attrib->nodeValue
+                    );
+                }
+            }
+        }
+    } catch (Exception $e) {
+        throw new Exception("Error extracting attributes: " . $e->getMessage());
+    }
     return $ret;
 }

--- a/scripts/translation/qaxml.a.php
+++ b/scripts/translation/qaxml.a.php
@@ -77,21 +77,18 @@ foreach ( $qalist as $qafile )
 function extractTriple(array $list)
 {
     $ret = array();
-    try {
-        foreach ($list as $elem) {
-            if ($elem->hasAttributes()) {
-                foreach ($elem->attributes as $attrib) {
-                    $ret[] = sprintf(
-                        "%s %s %s",
-                        $elem->nodeName,
-                        $attrib->nodeName,
-                        $attrib->nodeValue
-                    );
-                }
+    foreach ($list as $elem) {
+        if ($elem->hasAttributes()) {
+            foreach ($elem->attributes as $attrib) {
+                $ret[] = sprintf(
+                    "%s %s %s",
+                    $elem->nodeName,
+                    $attrib->nodeName,
+                    $attrib->nodeValue
+                );
             }
         }
-    } catch (Exception $e) {
-        throw new Exception("Error extracting attributes: " . $e->getMessage());
     }
     return $ret;
 }
+


### PR DESCRIPTION
Add defensive check using ```hasAttributes()``` before iterating over 
element attributes in extractTriple function. This prevents 
unnecessary iteration and potential errors when processing XML 
elements without attributes.

Before:
- Directly iterates over attributes
- Could cause warnings on elements without attributes

After:
- Checks for attributes first
- Skips elements without attributes
- More efficient processing
