### PR TITLE
Remove unused variables, fix disabled QA sync tools

### DIFF
--- a/scripts/translation/lib/RevcheckFileItem.php
+++ b/scripts/translation/lib/RevcheckFileItem.php
@@ -23,8 +23,6 @@ class RevcheckFileItem
 {
     public string $file = ""; // from fs
     public int    $size = 0 ; // from fs
-    public string $head = ""; // from vcs, source only, head hash, may be skipped
-    public string $diff = ""; // from vcs, source only, diff hash, no skips
     public int    $date = 0 ; // from vcs, source only, date of head or diff commit
     public string $hashLast = ""; // derived by addGitLogData
     public string $hashDiff = ""; // derived by addGitLogData, isSyncHash
@@ -39,8 +37,6 @@ class RevcheckFileItem
     {
         $this->file = $file;
         $this->size = $size;
-        $this->head = "";
-        $this->diff = "";
         $this->date = 0;
         $this->status = RevcheckStatus::Untranslated;
         $this->revtag = null;
@@ -71,7 +67,7 @@ class RevcheckFileItem
             $this->hashStop = true;
     }
 
-    public function isSyncHash( $hash )
+    public function isSyncHash( $hash ) : bool
     {
         $sync = in_array( $hash , $this->hashList );
         if ( $sync )

--- a/scripts/translation/lib/RevcheckRun.php
+++ b/scripts/translation/lib/RevcheckRun.php
@@ -98,21 +98,18 @@ class RevcheckRun
                 continue;
             }
 
-            // TODO remove $(source|target)H* with QA simplification
-
-            // Previous code compares uptodate on multiple hashs. The last hash or the last non-skipped hash.
-            // See https://github.com/php/doc-base/blob/090ff07aa03c3e4ad7320a4ace9ffb6d5ede722f/scripts/revcheck.php#L374
-            // and https://github.com/php/doc-base/blob/090ff07aa03c3e4ad7320a4ace9ffb6d5ede722f/scripts/revcheck.php#L392 .
-
-            $sourceHsh1 = $source->head;
-            $sourceHsh2 = $source->diff;
-            $targetHash = $target->revtag->revision;
-
             $daysOld = ( strtotime( "now" ) - $source->date ) / 86400;
             $daysOld = (int)$daysOld;
 
-            $qaInfo = new QaFileInfo( $sourceHsh1 , $targetHash , $this->sourceDir , $this->targetDir , $source->file , $daysOld );
-            $this->qaList[ $source->file ] = $qaInfo;
+            // TODO Make QA related state detect changes and autogenerate
+            // TODO Move all QA related code outside of RevcheckRun
+            {
+                $sourceHash = $source->isSyncHash( $target->revtag->revision ) ? $source->hashDiff : $source->hashLast;
+                $targetHash = $target->revtag->revision;
+
+                $qaInfo = new QaFileInfo( $sourceHash , $targetHash , $this->sourceDir , $this->targetDir , $source->file , $daysOld );
+                $this->qaList[ $source->file ] = $qaInfo;
+            }
 
             // TranslatedOk
 


### PR DESCRIPTION
I have plans to separate the QA sync tool code from `RunRevcheck.php` at a later time, but today I found the QA sync tools themselves got disabled after some merges. This is a quick fix to re-enable the tools, and delete properties that are not being filled anymore.

I will try test this on all translations, and plan to merge as soon as possible