### PR TITLE
Loop until xinclude() gets 0 includes

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -775,13 +775,19 @@ if ($didLoad === false) {
 echo "done.\n";
 
 echo "Running XInclude/XPointer... ";
-$status = $dom->xinclude();
+$statusCount = 0;
+do {
+    $status = $dom->xinclude();
+    if ($status !== -1) {
+        // For some dumb reason when no substitution are made it returns false instead of 0...
+        $status = (int) $status;
+        $statusCount += $status;
+    }
+} while ($status !== -1 && $status > 0);
 if ($status === -1) {
     echo "failed.\n";
 } else {
-    /* For some dumb reason when no substitution are made it returns false instead of 0... */
-    $status = (int) $status;
-    echo "done. Performed $status XIncludes\n";
+    echo "done. Performed $statusCount XIncludes\n";
 }
 flush();
 

--- a/configure.php
+++ b/configure.php
@@ -782,6 +782,7 @@ do {
         // For some dumb reason when no substitution are made it returns false instead of 0...
         $status = (int) $status;
         $statusCount += $status;
+        echo "included $status\n...";
     }
 } while ($status !== -1 && $status > 0);
 if ($status === -1) {


### PR DESCRIPTION
Workaround for libxml2 < 2.11.0 that apparently do not process nested xincludes.

See [this conversation](https://github.com/php/doc-en/pull/4163#issuecomment-2510217691)