### PR TITLE
Document and complement XInclude failures as warnings on translations

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -816,8 +816,8 @@ if ( $ac['XPOINTER_REPORTING'] == 'yes' || $ac['LANG'] == 'en' )
 
 if ( $ac['LANG'] != 'en' )
 {
-    // XInclude failures are soft erros on translations, so replace
-    // residual XInclude tags on translations to keep then building.
+    // XInclude failures are soft errors on translations, so remove
+    // residual XInclude tags on translations to keep them building.
 
     $explain = false;
 
@@ -844,7 +844,7 @@ if ( $ac['LANG'] != 'en' )
 //              $fixup = "<varlistentry><term>></term><listitem><simpara></simpara></listitem></varlistentry>";
 //              break;
             default:
-                echo "Unknown parent element at XInclude failure: $tagName\n";
+                echo "Unknown parent element of failed XInclude: $tagName\n";
                 $explain = true;
                 continue 2;
         }
@@ -863,8 +863,9 @@ if ( $ac['LANG'] != 'en' )
         echo <<<MSG
 \nIf you are seeing this message on a translation, this means that
 XInclude/XPointers failures reported above are so many or unknown,
-so that configure.php cannot patch the translated manual in a consistent
-state. Please report this issue on the doc-base repository.\n\n
+that configure.php cannot patch the translated manual into a validating
+state. Please report any "Unknown parent" messages on the doc-base
+repository, and focus on fixing XInclude/XPointers failures above.\n\n
 MSG;
         exit(-1); // stop here, do not let more messages further confuse the matter
     }

--- a/configure.php
+++ b/configure.php
@@ -814,10 +814,16 @@ if ( $ac['XPOINTER_REPORTING'] == 'yes' || $ac['LANG'] == 'en' )
     }
 }
 
-{   # Automatic xi:include / xi:fallback fixups
+if ( $ac['LANG'] != 'en' )
+{
+    // XInclude failures are soft erros on translations, so replace
+    // residual XInclude tags on translations to keep then building.
+
+    $explain = false;
 
     $xpath = new DOMXPath( $dom );
-    $nodes = $xpath->query( "//*[local-name()='include']" );
+    $xpath->registerNamespace( "xi" , "http://www.w3.org/2001/XInclude" );
+    $nodes = $xpath->query( "//xi:include" );
     foreach( $nodes as $node )
     {
         $fixup = null;
@@ -831,8 +837,15 @@ if ( $ac['XPOINTER_REPORTING'] == 'yes' || $ac['LANG'] == 'en' )
             case "refsect1":
                 $fixup = "<title></title>";
                 break;
+            case "tbody":
+                $fixup = "<row><entry></entry></row>";
+                break;
+//          case "variablelist":
+//              $fixup = "<varlistentry><term>></term><listitem><simpara></simpara></listitem></varlistentry>";
+//              break;
             default:
-                echo "Unknown parent element, validation may fail: $tagName\n";
+                echo "Unknown parent element at XInclude failure: $tagName\n";
+                $explain = true;
                 continue 2;
         }
         if ( $fixup != "" )
@@ -843,6 +856,17 @@ if ( $ac['XPOINTER_REPORTING'] == 'yes' || $ac['LANG'] == 'en' )
             $node->parentNode->insertBefore( $insert , $node );
         }
         $node->parentNode->removeChild( $node );
+    }
+
+    if ( $explain )
+    {
+        echo <<<MSG
+\nIf you are seeing this message on a translation, this means that
+XInclude/XPointers failures reported above are so many or unknown,
+so that configure.php cannot patch the translated manual in a consistent
+state. Please report this issue on the doc-base repository.\n\n
+MSG;
+        exit(-1); // stop here, do not let more messages further confuse the matter
     }
 }
 


### PR DESCRIPTION
This PR better document how XInclude failures are treated on translations. It only cares for `<xi:include>` **without** `<xi:failback>`, so it leaves open `<xi:failback>` usage for other situations.

In fact, I tested this on all languages with `doc-en` stripped of `<xi:failback>`.

As an recommendation, I suggest mass removing all mentions of `<xi:failback>` on `doc-en`, down to XML comments, after 8.4 doc changes calms down, and possibly further creating an github action/trigger that recuses usage of `<xi:failback>`, linking this trigger to mention `XInclude failures are soft errors on translations`. on `configure.php`. The reason being that failed XInclude leaves different artifacts in the presence and absence of `<xi:failback>`. Caring for both is very confusing.