### PR TITLE
XInclude by xml:id 

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -16,6 +16,7 @@
   | Authors:    Dave Barr <dave@php.net>                                 |
   |             Hannes Magnusson <bjori@php.net>                         |
   |             Gwynne Raskind <gwynne@php.net>                          |
+  |             André L F S Bacci <gwynne@php.net>                       |
   +----------------------------------------------------------------------+
 */
 
@@ -803,46 +804,140 @@ else
 
 
 echo "Running XInclude/XPointer... ";
-$total = 0;
-$maxrun = 10; //LIBXML_VERSION >= 21100 ? 1 : 10;
-for( $run = 0 ; $run < $maxrun ; $run++ )
-{
-    if ( $run > 0 )
-        echo "$run ";
-    libxml_clear_errors();
-    $status = (int) $dom->xinclude();
-    if ( $status <= 0 )
-        break;
-    $total += $status;
-    if ( $maxrun > 1 && $run + 1 >= $maxrun )
-    {
-        echo "Recursive XInclude is too deep.\n";
-        errors_are_bad(-1);
-    }
-}
 
-if ($total == 0) {
+$total  = xinclude_run_byid( $dom );
+$total += xinclude_run_xpointer( $dom );
+
+if ( $total == 0 )
     echo "failed.\n";
-} else {
+else
     echo "done. Performed $total XIncludes.\n";
-}
-flush();
 
-if ( $ac['XPOINTER_REPORTING'] == 'yes' || $ac['LANG'] == 'en' )
+xinclude_report();
+xinclude_residual( $dom );
+
+function xinclude_run_byid( DOMDocument $dom )
 {
-    $errors = libxml_get_errors();
-    $output = ( $ac['STDERR_TO_STDOUT'] == 'yes' ) ? STDOUT : STDERR;
-    if ( count( $errors ) > 0 )
+    $total = 0;
+    $maxrun = 10; //LIBXML_VERSION >= 21100 ? 1 : 10;
+    for( $run = 0 ; $run < $maxrun ; $run++ )
     {
-        fprintf( $output , "\n");
-        foreach( $errors as $error )
-            fprintf( $output , "{$error->message}\n");
-        if ( $ac['LANG'] == 'en' )
-            errors_are_bad(1);
+        echo "$run ";
+        $xpath = new DOMXPath( $dom );
+        $xpath->registerNamespace( "xi" , "http://www.w3.org/2001/XInclude" );
+        $xincludes = $xpath->query( "//xi:include" );
+
+        $changed = false;
+        foreach( $xincludes as $xinclude )
+        {
+            $xpointer = $xinclude->getAttribute( "xpointer" );
+            $target = $xinclude->ownerDocument->getElementById( $xpointer );
+
+            if ( $target == null )
+                continue;
+
+            $other = new DOMDocument( '1.0' , 'utf8' );
+            $frags = $other->createDocumentFragment();
+            $other->append( $frags );
+            $frags->append( $other->importNode( $target , true ) ); // dup add
+
+            // "attributes in xml: namespace are not copied"
+
+            $oxpth = new DOMXPath( $other );
+            $attribs = $oxpth->query( "//@*" );
+
+            foreach( $attribs as $attrib )
+                if ( $attrib->prefix == "xml" )
+                    $attrib->parentNode->removeAttribute( $attrib->nodeName );
+
+            $insert = $dom->importNode( $frags , true );                // dup
+            $xinclude->parentNode->insertBefore( $insert , $xinclude ); // add
+            $xinclude->parentNode->removeChild( $xinclude );            // del
+
+            $total++;
+            $changed = true;
+            libxml_clear_errors();
+        }
+
+        if ( ! $changed )
+            return $total;
+    }
+    echo "XInclude nested too deeply (xml:id).\n";
+    errors_are_bad( -1 );
+}
+
+function xinclude_run_xpointer( DOMDocument $dom ) : int
+{
+    $total = 0;
+    $maxrun = 10; //LIBXML_VERSION >= 21100 ? 1 : 10;
+    for( $run = 0 ; $run < $maxrun ; $run++ )
+    {
+        echo "$run ";
+        $status = (int) $dom->xinclude();
+
+        if ( $status <= 0 )
+        {
+            return $total;
+        }
+        $total += $status;
+        libxml_clear_errors();
+    }
+    echo "XInclude nested too deeply (xpointer).\n";
+    errors_are_bad( -1 );
+}
+
+function xinclude_report()
+{
+    global $ac;
+
+    $report = $ac['XPOINTER_REPORTING'] == 'yes' || $ac['LANG'] == 'en';
+    $output = $ac['STDERR_TO_STDOUT'] == 'yes' ? STDOUT : STDERR;
+    $fatal  = $ac['LANG'] == 'en';
+
+    $errors = libxml_get_errors();
+    libxml_clear_errors();
+
+    if ( ! $report )
+        return;
+
+    $count = 0;
+    $prefix = realpath( __DIR__ );
+
+    $prevLine = -1;
+    $prevClmn = -1;
+
+    foreach( $errors as $error )
+    {
+        $msg  = $error->message;
+        $file = $error->file;
+        $line = $error->line;
+        $clmn = $error->column;
+
+        if ( $prevLine == $line && $prevClmn == $clmn )
+            continue; // XPointer failures double reports sometimes
+        $prevLine = $line;
+        $prevClmn = $clmn;
+
+        $msg = rtrim( $msg );
+        if ( str_starts_with( $file , $prefix ) )
+            $file = substr( $file , strlen( $prefix ) + 1 );
+
+        if ( $count == 0 )
+            fprintf( $output , "\n" );
+
+        fprintf( $output , "[{$file} {$line}:{$clmn}] $msg\n" );
+        $count++;
+    }
+
+    if ( $count > 0 )
+    {
+        fprintf( $output , "\n" );
+        if ( $fatal )
+            errors_are_bad( 1 );
     }
 }
 
-if ( $ac['LANG'] != 'en' )
+function xinclude_residual( DOMDocument $dom )
 {
     // XInclude failures are soft errors on translations, so remove
     // residual XInclude tags on translations to keep them building.
@@ -868,11 +963,11 @@ if ( $ac['LANG'] != 'en' )
             case "tbody":
                 $fixup = "<row><entry></entry></row>";
                 break;
-//          case "variablelist":
-//              $fixup = "<varlistentry><term>></term><listitem><simpara></simpara></listitem></varlistentry>";
-//              break;
+            case "variablelist":
+                $fixup = "<varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry>";
+                break;
             default:
-                echo "Unknown parent element of failed XInclude: $tagName\n";
+                echo "Unknown parent of failed XInclude: $tagName\n";
                 $explain = true;
                 continue 2;
         }
@@ -896,6 +991,23 @@ state. Please report any "Unknown parent" messages on the doc-base
 repository, and focus on fixing XInclude/XPointers failures above.\n\n
 MSG;
         exit(-1); // stop here, do not let more messages further confuse the matter
+    }
+
+    // XInclude by xml:id never duplicates xml:id, horever, also using
+    // XInclude by XPath/XPointer may start causing duplications
+    // (see docs/structure.md). Crude and ugly fixup ahead, beware!
+
+    $list = array();
+    $nodes = $xpath->query( "//*[@xml:id]" );
+    foreach( $nodes as $node )
+    {
+        $id = $node->getAttribute( "xml:id" );
+        if ( isset( $list[ $id ] ) )
+        {
+            echo "  Random removing duplicated xml:id: $id\n";
+            $node->removeAttribute( "xml:id" );
+        }
+        $list[ $id ] = $id;
     }
 }
 
@@ -997,4 +1109,3 @@ CAT;
 
     errors_are_bad(1); // Tell the shell that this script finished with an error.
 }
-?>

--- a/configure.php
+++ b/configure.php
@@ -779,13 +779,15 @@ function dom_load( DOMDocument $dom , string $filename ) : bool
     return $dom->load( $filename , $options );
 }
 
-function dom_saveload( DOMDocument $dom , string $filename = "" )
+function dom_saveload( DOMDocument $dom , string $filename = "" ) : string
 {
     if ( $filename == "" )
         $filename = __DIR__ . "/temp/manual.xml";
 
     $dom->save( $filename );
     dom_load( $dom , $filename );
+
+    return $filename;
 }
 
 echo "Loading and parsing {$ac["INPUT_FILENAME"]}... ";
@@ -863,7 +865,7 @@ function xinclude_run_byid( DOMDocument $dom )
             return $total;
     }
     echo "XInclude nested too deeply (xml:id).\n";
-    errors_are_bad( -1 );
+    errors_are_bad( 1 );
 }
 
 function xinclude_run_xpointer( DOMDocument $dom ) : int
@@ -883,7 +885,7 @@ function xinclude_run_xpointer( DOMDocument $dom ) : int
         libxml_clear_errors();
     }
     echo "XInclude nested too deeply (xpointer).\n";
-    errors_are_bad( -1 );
+    errors_are_bad( 1 );
 }
 
 function xinclude_report()
@@ -990,7 +992,7 @@ that configure.php cannot patch the translated manual into a validating
 state. Please report any "Unknown parent" messages on the doc-base
 repository, and focus on fixing XInclude/XPointers failures above.\n\n
 MSG;
-        exit(-1); // stop here, do not let more messages further confuse the matter
+        exit(1); // stop here, do not let more messages further confuse the matter
     }
 
     // XInclude by xml:id never duplicates xml:id, horever, also using
@@ -1004,7 +1006,8 @@ MSG;
         $id = $node->getAttribute( "xml:id" );
         if ( isset( $list[ $id ] ) )
         {
-            echo "  Random removing duplicated xml:id: $id\n";
+            if ( ! str_contains( $id , '..' ) )
+                echo "  Random removing duplicated xml:id: $id\n";
             $node->removeAttribute( "xml:id" );
         }
         $list[ $id ] = $id;

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -5,6 +5,7 @@ The PHP Manual sources are stored in Git repositories.
 To checkout the PHP Manual sources, follow the steps in [Setting up a documentation environment](local-setup.md)
 
 ## File structure
+
 **Note for translators:** if any of the source files don't exist in your translation, the English content will be used
 during the building process. This means that you *must not* place untranslated files in your translation tree. Otherwise,
 it will lead to a mess, confusion and may break some tools.
@@ -42,3 +43,19 @@ There are some other important files:
   Including common warnings, notes, etc.
 - *translation.xml* - this file is used to store all central translation info, like a small
   intro text for translators and the persons list. This file is not present in the English tree.
+
+## `xml:id` structure
+
+The PHP is complex, and uses `xml:id` extensively. For chunking,
+linking and XInclude purposes. So some care is necessary to avoid
+collisions. There are two pseudo-types of IDs used in manuals.
+
+* **Structural IDs:** IDs that are present on structural elements of
+DocBook XML (like `<chapter>`, `<section>` and so on);
+
+* **XInclude IDs:** IDs that are used as target of XIncludes.
+
+Structural IDs are in the pattern `id.id`, while XInclude IDs use the
+pattern `structural.id..local.name`. That is, Structural IDs, the
+name parts are separated with a single dot, while XInclude IDs start
+with an Structural ID, an `..` separator, and a local path suffix.


### PR DESCRIPTION
This PR enhances `configure.php` to add XInclude 1.1 partial implementation. That is, XInclude by `xml:id`. Also, it moves the various sections of XInclude functionality into functions, to avoid polluting the global namespace. Points of interest:

* `xinclude_run_byid()`: where the new magic occurs;
* the new code, starting after `if ( $explain )`.

With this PR, would be possible to change manual like this:
```diff
diff --git a/reference/filesystem/functions/fgetcsv.xml b/reference/filesystem/functions/fgetcsv.xml
index 7e1ba4046d..9e313d2630 100644
--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -62,7 +62,7 @@
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry>
+    <varlistentry xml:id="function.fgetcsv..parameters.separator">
      <term><parameter>separator</parameter></term>
      <listitem>
       <para>
@@ -71,7 +71,7 @@
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry>
+    <varlistentry xml:id="function.fgetcsv..parameters.enclosure">
      <term><parameter>enclosure</parameter></term>
      <listitem>
       <para>
@@ -80,7 +80,7 @@
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry>
+    <varlistentry xml:id="function.fgetcsv..parameters.escape">
      <term><parameter>escape</parameter></term>
      <listitem>
       <para>
diff --git a/reference/filesystem/functions/fputcsv.xml b/reference/filesystem/functions/fputcsv.xml
index f3a94fb1b1..ccaf4a3622 100644
--- a/reference/filesystem/functions/fputcsv.xml
+++ b/reference/filesystem/functions/fputcsv.xml
@@ -43,15 +43,9 @@
       </para>
      </listitem>
     </varlistentry>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="function.fgetcsv..parameters.separator"/>
+    <xi:include xpointer="function.fgetcsv..parameters.enclosure"/>
+    <xi:include xpointer="function.fgetcsv..parameters.escape"/>
     <varlistentry>
      <term><parameter>eol</parameter></term>
      <listitem>
```

The format for XInclude ID targets, `id.on.file dot dot local.path` is not special. It is only a convention, but I think it is a **good** one, because:

* It helps differentiate between "structural" IDs and these XInclude target IDs;
* It helps indicate what parts of manual are expected to be copied elsewhere;
* It helps debug some unexpected, but possibly duplicated xml:id, in some cases.

That last point warrants a detailed explanation. Running this PR with the patch above also illustrates the point. Until now, XIncludes by XPath/XPointer was not duplicating IDs because it would generate a validation error. So XInclude by path, targeting elements with IDs are impossible to pull off. XInclude by xml:id never duplicates any IDs. But *mixed includes by path and ID probably will* duplicate IDs, at least temporary, in `doc-en` and translations, because there will be more xml:ids around, positioned exactly where parts of manual are targeted for duplication by paths.

The patch above generates this warnings:

```
  Random removing duplicated xml:id: function.fgetcsv..parameters.separator
  Random removing duplicated xml:id: function.fgetcsv..parameters.enclosure
  Random removing duplicated xml:id: function.fgetcsv..parameters.escape
  Random removing duplicated xml:id: function.fgetcsv..parameters.separator
  Random removing duplicated xml:id: function.fgetcsv..parameters.enclosure
  Random removing duplicated xml:id: function.fgetcsv..parameters.escape
```

That is, there are six XIndluces by path that pull parts of the manual with xml:ids. This could occur in translations, each time an ID targeted XInclude is added. I [could not](https://github.com/php/doc-base/pull/187#issuecomment-2511814555) find a reliable way to delete IDs, only from duplicated nodes, so this is what I came up with.

This PR has the potential to really shrink `language-snippets.ent`, by placing a lot of related entities in their related extensions, and XIncluding them elsewhere.

And... that's it. Reviews and comments welcome. HT to a [humble comment](https://github.com/php/doc-en/blob/23d4ebeeb5fb4ad24acb8a63f062f3406de3b2bc/install/ini.xml#L270), that started this all.