### PR TITLE
Windows related changes, ahead/behind only current branch

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -649,11 +649,11 @@ foreach ( $repos as $name => $path )
 {
     $path = escapeshellarg( $path );
     $branch = trim( `git -C $path rev-parse --abbrev-ref HEAD` );
-    $branch = $branch == "master" ? "" : " (branch $branch)";
+    $suffix = $branch == "master" ? "" : " (branch $branch)";
     $output .= str_pad( "$name:" , 10 );
-    $output .= rtrim( `git -C $path rev-parse HEAD`  ?? "" ) . "$branch\n";
+    $output .= rtrim( `git -C $path rev-parse HEAD`  ?? "" ) . "$suffix ";
+    $output .= rtrim( `git -C $path for-each-ref --format="%(push:track)" refs/heads/$branch` ?? "" ) . "\n";
     $output .= rtrim( `git -C $path status -s` ?? "" ) . "\n";
-    $output .= rtrim( `git -C $path for-each-ref --format="%(push:track)" refs/heads` ?? "" ) . "\n";
 }
 while( str_contains( $output , "\n\n" ) )
     $output = str_replace( "\n\n" , "\n" , $output );

--- a/languages.php
+++ b/languages.php
@@ -101,6 +101,7 @@ class Lang
         , public string $path = "" )
     {
         $this->path = realpath( __DIR__ . '/..' ) . "/{$code}";
+        $this->path = str_replace( "\\" , '/' , $this->path );
     }
 }
 

--- a/scripts/file-entities.php
+++ b/scripts/file-entities.php
@@ -18,7 +18,7 @@
 # Description
 
 This script creates various "file entities", that is, DTD entities that
-points to files and file listings, named and composed of:
+point to files and file listings, named and composed of:
 
 - dir.dir.file : pulls in a dir/dir/file.xml file
 - dir.dif.entities.dir : pulls in all files of dir/dir/dir/*.xml

--- a/scripts/file-entities.php
+++ b/scripts/file-entities.php
@@ -328,3 +328,4 @@ function realpain( string $path , bool $touch = false ) : string
 
     return $path;
 }
+

--- a/scripts/file-entities.php
+++ b/scripts/file-entities.php
@@ -314,11 +314,10 @@ function realpain( string $path , bool $touch = false ) : string
 {
     // pain is real
 
-    // care for external XML tools (realpath everywhere)
+    // care for external XML tools (realpath() everywhere)
     // care for Windows builds (foward slashes everywhere)
     // avoid `cd` and chdir() like the plague
 
-    $path = str_replace( "\\" , '/' , $path );
     if ( $touch && ! file_exists( $path ) )
         touch( $path );
 
@@ -328,4 +327,3 @@ function realpain( string $path , bool $touch = false ) : string
 
     return $path;
 }
-

--- a/scripts/file-entities.php
+++ b/scripts/file-entities.php
@@ -323,7 +323,7 @@ function realpain( string $path , bool $touch = false ) : string
         touch( $path );
 
     $res = realpath( $path );
-    if ( is_string( $res ) )
+    if ($res !== false)
         $path = $res;
 
     return $path;


### PR DESCRIPTION
This PR makes `languages.php` more functional on Windows, and also changes repository status to not show ahead/behind of unrelated branches.

As a heads up, also remove a ugly hack for dirs named `PDO` vs `pdo`. If you are on Windows, and start receiving errors of undefined entities that contains `PDO` (upper case), you may need to filesystem remove all files from `en/reference/pdo*`, and then `git restore` then, as git on Windows may not honor case changing moves.