### PR TITLE
XML fragment fixup for `refsect1`

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -964,7 +964,7 @@ function xinclude_residual( DOMDocument $dom )
                 $fixup = "";
                 break;
             case "refsect1":
-                $fixup = "<title></title><note><simpara>[failed xi:xinclude]</simpara></note>";
+                $fixup = "<title>_</title><simpara>%failed xi:xinclude%</simpara>";
                 break;
             case "tbody":
                 $fixup = "<row><entry></entry></row>";

--- a/configure.php
+++ b/configure.php
@@ -964,7 +964,7 @@ function xinclude_residual( DOMDocument $dom )
                 $fixup = "";
                 break;
             case "refsect1":
-                $fixup = "<title>_</title><simpara>%failed xi:xinclude%</simpara>";
+                $fixup = "<title>_</title><simpara>_</simpara>"; // https://github.com/php/phd/issues/181
                 break;
             case "tbody":
                 $fixup = "<row><entry></entry></row>";

--- a/configure.php
+++ b/configure.php
@@ -964,7 +964,7 @@ function xinclude_residual( DOMDocument $dom )
                 $fixup = "";
                 break;
             case "refsect1":
-                $fixup = "<title></title>";
+                $fixup = "<title></title><note><simpara>[failed xi:xinclude]</simpara></note>";
                 break;
             case "tbody":
                 $fixup = "<row><entry></entry></row>";
@@ -980,9 +980,12 @@ function xinclude_residual( DOMDocument $dom )
         if ( $fixup != "" )
         {
             $other = new DOMDocument( '1.0' , 'utf8' );
-            $other->loadXML( $fixup );
-            $insert = $dom->importNode( $other->documentElement , true );
-            $node->parentNode->insertBefore( $insert , $node );
+            $other->loadXML( "<f>$fixup</f>" );
+            foreach( $other->documentElement->childNodes as $otherNode )
+            {
+                $imported = $dom->importNode( $otherNode , true );
+                $node->parentNode->insertBefore( $imported , $node );
+            }
         }
         $node->parentNode->removeChild( $node );
     }


### PR DESCRIPTION
This PR changes the fix up for `refsect1` to `<title>_</title><simpara>%failed xi:xinclude%</simpara>`. As this cannot be parsed as an XML document, code is also changed to support fix ups that are XML fragments.

This PR, https://github.com/php/doc-it/issues/55 and `doc-en` patch below fixes `doc-it` building.
```diff
diff --git a/reference/gmp/gmp/construct.xml b/reference/gmp/gmp/construct.xml
index df2e9e0893..cdc32f70bb 100644
--- a/reference/gmp/gmp/construct.xml
+++ b/reference/gmp/gmp/construct.xml
@@ -18,9 +18,7 @@
  </refsect1>
 
  <refsect1 role="parameters">
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.gmp-init')/db:refsect1[@role='parameters']/*)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.gmp-init')/db:refsect1[@role='parameters']/*)"/>
  </refsect1>
 
  <refsect1 role="seealso">
```

Two notes:

1. This is a small-scale example of the effects of removing `<xi:fallback>` from sources, as the automatic fixups can push/keep translations into building state.
2. I think I found a bug on PhD, while developing this.

The fixup `<title></title><simpara>%failed xi:xinclude%</simpara>` (empty title) is saved on `.manual.xml` as:
```xml
<refsect1 role="parameters">
 <title/><simpara>%failed xi:xinclude%</simpara>
</refsect1
```
and is rendered by `php phd/render.php --format bigxhtml` as:

```html
<div class="refsect1 parameters" id="refsect1-function.bcdivmod-parameters">
  <h3 class="title"><p class="simpara">%failed xi:xinclude%</p></h3>
</div>
```

Instead of:

```html
<div class="refsect1 parameters" id="refsect1-function.bcdivmod-parameters">
  <h3 class="title"></h3>
  <p class="simpara">%failed xi:xinclude%</p>
</div>
```

In other words, empty `<title>` causes their siblings to be rendered inside the title, instead of around it.

To workaround this, and to avoid rendering `%failed xi:xinclude%` as big as titles, I placed an `_` inside de title.

I'm not so certain about `%failed xi:xinclude%`/`_`. Another alternative was to keep these elements empty, so XInclude failures does not inject warnings in rendered manuals, and would like comments about this.