### PR TITLE
Avoid warnings in PHP 8.4

### DIFF
--- a/scripts/translation/lib/QaFileInfo.php
+++ b/scripts/translation/lib/QaFileInfo.php
@@ -54,7 +54,7 @@ class QaFileInfo
         foreach( $itens as $item )
         {
             $line = array( $item->sourceHash , $item->targetHash , $item->sourceDir , $item->targetDir , $item->file , $item->days );
-            fputcsv( $fp , $line, ",", "\"", "\\" );
+            fputcsv( $fp , $line, escape: "" );
         }
         fclose($fp);
     }

--- a/scripts/translation/lib/QaFileInfo.php
+++ b/scripts/translation/lib/QaFileInfo.php
@@ -54,7 +54,7 @@ class QaFileInfo
         foreach( $itens as $item )
         {
             $line = array( $item->sourceHash , $item->targetHash , $item->sourceDir , $item->targetDir , $item->file , $item->days );
-            fputcsv( $fp , $line );
+            fputcsv( $fp , $line, ",", "\"", "\\" );
         }
         fclose($fp);
     }

--- a/scripts/translation/lib/RevcheckFileItem.php
+++ b/scripts/translation/lib/RevcheckFileItem.php
@@ -19,7 +19,6 @@
 
 require_once __DIR__ . '/all.php';
 
-#[\AllowDynamicProperties]
 class RevcheckFileItem
 {
     public string $file = ""; // from fs
@@ -63,7 +62,7 @@ class RevcheckFileItem
         }
 
         if ( $skip )
-            $this->diffHash = $hash;
+            $this->hashDiff = $hash;
         else
             $this->hashStop = true;
     }

--- a/scripts/translation/lib/RevcheckFileItem.php
+++ b/scripts/translation/lib/RevcheckFileItem.php
@@ -19,6 +19,7 @@
 
 require_once __DIR__ . '/all.php';
 
+#[\AllowDynamicProperties]
 class RevcheckFileItem
 {
     public string $file = ""; // from fs


### PR DESCRIPTION
fputcsv() escape parameter must be provided as of PHP 8.4. The other preceding parameters are also informed. Named arguments not used for backwards compatibility with PHP < 8.0.

Using `#[\AllowDynamicProperties]` to the class to avoid warnings in PHP 8.2+.

