### PR TITLE
Fix Windows build (forward slashes everywhere)

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -110,7 +110,7 @@ function realpain( string $path , bool $touch = false , bool $mkdir = false ) : 
 
     $res = realpath( $path );
     if ( is_string( $res ) )
-        $path = $res;
+        $path = str_replace( "\\" , '/' , $res );
 
     return $path;
 }

--- a/scripts/file-entities.php
+++ b/scripts/file-entities.php
@@ -310,7 +310,7 @@ function writeEntity( $file , Entity $ent )
     fwrite( $file , $line );
 }
 
-function realpain( string $path , bool $touch = false ) : string
+function realpain( string $path , bool $touch = false , bool $mkdir = false ) : string
 {
     // pain is real
 
@@ -318,12 +318,17 @@ function realpain( string $path , bool $touch = false ) : string
     // care for Windows builds (foward slashes everywhere)
     // avoid `cd` and chdir() like the plague
 
+    $path = str_replace( "\\" , '/' , $path );
+
+    if ( $mkdir && ! file_exists( $path ) )
+        mkdir( $path , recursive: true );
+
     if ( $touch && ! file_exists( $path ) )
         touch( $path );
 
     $res = realpath( $path );
-    if ($res !== false)
-        $path = $res;
+    if ( is_string( $res ) )
+        $path = str_replace( "\\" , '/' , $res );
 
     return $path;
 }


### PR DESCRIPTION
There is nobody building on Windows? Or, there is way to CI test on Windows boxes? I can only borrow a Windows box very rarely to test these things.

On a Win10 machine, this PR fixes:

```
C:\phpdoc>php doc-base\configure.php -q --disable-sources-file --with-lang=de
configure.php on PHP 8.3.14

doc-base: e62034723f03e24728247468043a2c5ffc358a34
en:       f944fb771cf18594fd89f3568f216b4f1a2b7002
de:       d3c11067a19da9059d28b58c8d6f3a9c64a02cf0

Iterating over extension specific version files... OK
Saving it... OK
Modification history file C:\phpdoc/en/fileModHistory.php not found.
Creating empty modification history file...done.
Creating file-entities.ent... done
Loading and parsing manual.xml... failed.

[error file:/C:/phpdoc/doc-base/temp/manual.conf 2:74] Invalid URI: C:\phpdoc\de\language-defs.ent
[error file:/C:/phpdoc/doc-base/temp/manual.conf 3:78] Invalid URI: C:\phpdoc\de\language-snippets.ent
[error file:/C:/phpdoc/doc-base/temp/manual.conf 4:71] Invalid URI: C:\phpdoc\de\extensions.ent
[error file:/C:/phpdoc/doc-base/manual.xml 9:19] PEReference: %translation-defs; not found
[error file:/C:/phpdoc/doc-base/manual.xml 10:23] PEReference: %translation-snippets; not found
[error file:/C:/phpdoc/doc-base/manual.xml 11:25] PEReference: %translation-extensions; not found
[FATAL C:/phpdoc/de/chapters/intro.xml 84:64] Entity 'zb' not defined
[FATAL C:/phpdoc/de/chapters/intro.xml 124:25] Entity 'zb' not defined
[FATAL C:/phpdoc/de/chapters/intro.xml 137:61] Entity 'zb' not defined
[FATAL C:/phpdoc/de/chapters/intro.xml 147:33] Entity 'zb' not defined
[FATAL C:/phpdoc/de/chapters/intro.xml 153:64] Entity 'zb' not defined
[FATAL C:/phpdoc/de/chapters/intro.xml 183:57] Entity 'zb' not defined
[FATAL C:/phpdoc/de/chapters/intro.xml 217:1] chunk is not well balanced
[FATAL file:/C:/phpdoc/doc-base/manual.xml 41:19] Entity 'chapters.intro' failed to parse

Eyh man. No worries. Happ shittens. Try again after fixing the errors above.
```