### PR TITLE
Merge to master before running tests

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -51,7 +51,7 @@ jobs:
           path: "en"
           repository: "php/doc-en"
 
-      - name: "Merge doc-base changes from master"
+      - name: "Ensure doc-base is correctly merged into master (debug)"
         run: |
           echo === This step will fail if the merge commit is not targeting master
           cd doc-base

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -53,6 +53,7 @@ jobs:
 
       - name: "Merge doc-base changes from master"
         run: |
+          git -C doc-base fetch master
           git -C doc-base -c user.email="()" -c user.name="()" merge --no-ff --no-commit master
           git -C doc-base diff --cached
 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: "Merge doc-base changes from master"
         run: |
-          git -C doc-base fetch master
+          git -C doc-base fetch origin/master
           git -C doc-base -c user.email="()" -c user.name="()" merge --no-ff --no-commit master
           git -C doc-base diff --cached
 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -60,7 +60,7 @@ jobs:
           php doc-base/scripts/qa/section-order.php
 
       - name: "Merge with master (to care for concurrent PRs)"
-        run: "git -C doc-base merge --no-ff --no-commit master"
+        run: "git -C doc-base merge --no-ff --no-commit origin/master"
 
       - name: "Build documentation for ${{ matrix.language }}"
         run: "php doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -53,12 +53,12 @@ jobs:
 
       - name: "Merge doc-base changes from master"
         run: |
-          cd doc-base
           ls
-          git status
-          git remote -v
+          cd doc-base
           git fetch origin master
-          gir branch
+          echo "status" ; git status
+          echo "remote" ; git remote -v
+          echo "branch" ; git branch
           git -c user.email="()" -c user.name="()" merge --no-ff --no-commit origin/master
           git diff --cached
 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -56,10 +56,14 @@ jobs:
           env
           cd doc-base
           git branch
+          git log -n 3
           git checkout master
-          git switch -
           git branch
-          git -c user.email="()" -c user.name="()" merge --no-ff --no-commit origin/master
+          git log -n 3
+          git switch --detach -
+          git branch
+          git log -n 3
+          git -c user.email="()" -c user.name="()" merge --no-ff --no-commit master
           git diff --cached
 
       - name: "Run QA scripts for EN docs"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -34,33 +34,33 @@ jobs:
           - "zh"
 
     steps:
-      - name: "Checkout"
+      - name: "Checkou doc-baset"
         uses: "actions/checkout@v4"
         with:
           path: "doc-base"
           fetch-depth: 0
 
-      - name: "Checkout php/doc-${{ matrix.language }}"
+      - name: "Checkout doc-${{ matrix.language }}"
         uses: "actions/checkout@v4"
         with:
           path: "${{ matrix.language }}"
           repository: "php/doc-${{ matrix.language }}"
 
-      - name: "Checkout php/doc-en as fallback"
+      - name: "Checkout doc-en (fallback)"
         if: "matrix.language != 'en'"
         uses: "actions/checkout@v4"
         with:
           path: "en"
           repository: "php/doc-en"
 
+      - name: "Merge doc-base with master (concurrent PRs)"
+        run: "git -C doc-base merge --no-ff --no-commit origin/master"
+
       - name: "Run QA scripts for EN docs"
         if: "matrix.language == 'en'"
         run: |
           php doc-base/scripts/qa/extensions.xml.php --check
           php doc-base/scripts/qa/section-order.php
-
-      - name: "Merge with master (to care for concurrent PRs)"
-        run: "git -C doc-base merge --no-ff --no-commit origin/master"
 
       - name: "Build documentation for ${{ matrix.language }}"
         run: "php doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -61,5 +61,5 @@ jobs:
       - name: "Build documentation for ${{ matrix.language }}"
         run: |
           git -C doc-base fetch origin master
-          git -C doc-base merge --no-ff --no-commit master
+          git -C doc-base merge --no-ff --no-commit origin/master
           php doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -60,5 +60,6 @@ jobs:
 
       - name: "Build documentation for ${{ matrix.language }}"
         run: |
+          git -C doc-base fetch origin master
           git -C doc-base merge --no-ff --no-commit master
           php doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -53,12 +53,12 @@ jobs:
 
       - name: "Merge doc-base changes from master"
         run: |
-          ls
+          env
           cd doc-base
-          git fetch origin master
-          echo "status" ; git status
-          echo "remote" ; git remote -v
-          echo "branch" ; git branch
+          git branch
+          git checkout master
+          git switch -
+          git branch
           git -c user.email="()" -c user.name="()" merge --no-ff --no-commit origin/master
           git diff --cached
 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -34,7 +34,7 @@ jobs:
           - "zh"
 
     steps:
-      - name: "Checkou doc-baset"
+      - name: "Checkout doc-base"
         uses: "actions/checkout@v4"
         with:
           path: "doc-base"
@@ -53,7 +53,7 @@ jobs:
           path: "en"
           repository: "php/doc-en"
 
-      - name: "Merge doc-base with master (concurrent PRs)"
+      - name: "Pull merged doc-base changes from master"
         run: "git -C doc-base merge --no-ff --no-commit origin/master"
 
       - name: "Run QA scripts for EN docs"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -59,4 +59,6 @@ jobs:
           php doc-base/scripts/qa/section-order.php
 
       - name: "Build documentation for ${{ matrix.language }}"
-        run: "php doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"
+        run: |
+          git -C doc-base merge --no-ff --no-commit master
+          php doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -60,6 +60,6 @@ jobs:
 
       - name: "Build documentation for ${{ matrix.language }}"
         run: |
-          git -C doc-base fetch origin master
+          git -C doc-base pull origin master
           git -C doc-base merge --no-ff --no-commit origin/master
           php doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -53,9 +53,14 @@ jobs:
 
       - name: "Merge doc-base changes from master"
         run: |
-          git -C doc-base fetch origin master
-          git -C doc-base -c user.email="()" -c user.name="()" merge --no-ff --no-commit master
-          git -C doc-base diff --cached
+          cd doc-base
+          ls
+          git status
+          git remote -v
+          git fetch origin master
+          gir branch
+          git -c user.email="()" -c user.name="()" merge --no-ff --no-commit origin/master
+          git diff --cached
 
       - name: "Run QA scripts for EN docs"
         if: "matrix.language == 'en'"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -53,18 +53,14 @@ jobs:
 
       - name: "Merge doc-base changes from master"
         run: |
-          env
+          echo === This step will fail if the merge commit is not targeting master
           cd doc-base
-          git branch
+          echo === git log -n 3
           git log -n 3
-          git checkout master
-          git branch
-          git log -n 3
-          git switch --detach -
-          git branch
-          git log -n 3
-          git -c user.email="()" -c user.name="()" merge --no-ff --no-commit master
-          git diff --cached
+          echo === git show HEAD
+          git show HEAD
+          echo === git merge --no-ff --no-commit master
+          git merge --no-ff --no-commit origin/master
 
       - name: "Run QA scripts for EN docs"
         if: "matrix.language == 'en'"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -38,6 +38,7 @@ jobs:
         uses: "actions/checkout@v4"
         with:
           path: "doc-base"
+          fetch-depth: 0
 
       - name: "Checkout php/doc-${{ matrix.language }}"
         uses: "actions/checkout@v4"
@@ -58,8 +59,8 @@ jobs:
           php doc-base/scripts/qa/extensions.xml.php --check
           php doc-base/scripts/qa/section-order.php
 
+      - name: "Merge with master (to care for concurrent PRs)"
+        run: "git -C doc-base merge --no-ff --no-commit master"
+
       - name: "Build documentation for ${{ matrix.language }}"
-        run: |
-          git -C doc-base pull origin master
-          git -C doc-base merge --no-ff --no-commit origin/master
-          php doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}
+        run: "php doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: "Merge doc-base changes from master"
         run: |
-          git -C doc-base fetch origin/master
+          git -C doc-base fetch origin master
           git -C doc-base -c user.email="()" -c user.name="()" merge --no-ff --no-commit master
           git -C doc-base diff --cached
 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -11,9 +11,7 @@ on:
 jobs:
   build:
     name: "Build"
-
     runs-on: "ubuntu-latest"
-
     continue-on-error: true
 
     strategy:
@@ -53,8 +51,10 @@ jobs:
           path: "en"
           repository: "php/doc-en"
 
-      - name: "Pull merged doc-base changes from master"
-        run: "git -C doc-base merge --no-ff --no-commit origin/master"
+      - name: "Merge doc-base changes from master"
+        run: |
+          git -C doc-base -c user.email="()" -c user.name="()" merge --no-ff --no-commit origin/master
+          git -C doc-base diff --cached
 
       - name: "Run QA scripts for EN docs"
         if: "matrix.language == 'en'"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: "Merge doc-base changes from master"
         run: |
-          git -C doc-base -c user.email="()" -c user.name="()" merge --no-ff --no-commit origin/master
+          git -C doc-base -c user.email="()" -c user.name="()" merge --no-ff --no-commit master
           git -C doc-base diff --cached
 
       - name: "Run QA scripts for EN docs"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@ sources.xml
 # File use to generate entities by configure script
 fileModHistory.php
 
-
 # A plece for all temporary or generated files (idempotent build)
 temp/


### PR DESCRIPTION
When a PR is branched from a point before current master, the CI tests are run *ignoring* any intermediary commits. In other words, tests are running considering one version that will never exist in practice.

To avoid this, run an local `git merge` from the branched checkout. This is a no-op if there is no commits to be merged.