### PR TITLE
Command line tool for XML sync testing between languages: entities

### DIFF
--- a/scripts/translation/libqa/OutputBuffer.php
+++ b/scripts/translation/libqa/OutputBuffer.php
@@ -67,7 +67,7 @@ class OutputBuffer
 
     public function addFooter( string $text )
     {
-        $this->footer[] = $text;
+        // $this->footer[] = $text;
     }
 
     public function addLine()

--- a/scripts/translation/libqa/SyncFileList.php
+++ b/scripts/translation/libqa/SyncFileList.php
@@ -31,7 +31,7 @@ class SyncFileList
         }
 
         $lang = trim( file_get_contents( $file ) );
-        $cache = __DIR__ . "/../../../temp/$lang.oklist";
+        $cache = __DIR__ . "/../../../temp/qaxml.files.$lang";
 
         if ( file_exists( $cache ) )
         {
@@ -47,7 +47,12 @@ class SyncFileList
 
         foreach( $revdata->fileDetail as $file )
         {
-            if ( $file->status != RevcheckStatus::TranslatedOk )
+            $source = "{$revcheck->sourceDir}/{$file->path}/{$file->name}";
+            $target = "{$revcheck->targetDir}/{$file->path}/{$file->name}";
+
+            if ( ! file_exists( $source ) )
+                continue;
+            if ( ! file_exists( $target ) )
                 continue;
 
             $item = new SyncFileItem();
@@ -56,6 +61,9 @@ class SyncFileList
             $item->file = $file->path . '/' . $file->name;
             $list[] = $item;
         }
+
+        if ( count( $list ) == 0 )
+            throw new Exception( "No files found. Called from wrong directory?" );
 
         $contents = gzencode( serialize( $list ) );
         file_put_contents( $cache , $contents );

--- a/scripts/translation/libqa/XmlFrag.php
+++ b/scripts/translation/libqa/XmlFrag.php
@@ -44,16 +44,16 @@ class XmlFrag
         [ $doc , $ent , $err ] = XmlFrag::loadXmlFragmentText( $contents , "" );
 
         if ( count( $err ) == 0 )
-            return [ $doc , $err ];
+            return [ $doc , $ent , $err ];
 
         $dtd = "<?xml version='1.0' encoding='utf-8'?>\n<!DOCTYPE frag [\n";
         foreach ( $ent as $e )
             $dtd .= "<!ENTITY $e ''>\n";
         $dtd .= "]>\n";
 
-        [ $doc , $ent , $err ] = XmlFrag::loadXmlFragmentText( $contents , $dtd );
+        [ $doc , $ign , $err ] = XmlFrag::loadXmlFragmentText( $contents , $dtd );
 
-        return [ $doc , $err ];
+        return [ $doc , $ent , $err ];
     }
 
     static function loadXmlFragmentText( string $contents , string $dtd )

--- a/scripts/translation/qaxml-sync-attributes.php
+++ b/scripts/translation/qaxml-sync-attributes.php
@@ -28,8 +28,8 @@ foreach ( $oklist as $file )
     $target = $file->targetDir . '/' . $file->file;
     $output = new OutputBuffer( "# qaxml.a" , $target , $ignore );
 
-    [ $s , $e ] = XmlFrag::loadXmlFragmentFile( $source );
-    [ $t , $e ] = XmlFrag::loadXmlFragmentFile( $target );
+    [ $s , $_ , $_ ] = XmlFrag::loadXmlFragmentFile( $source );
+    [ $t , $_ , $_ ] = XmlFrag::loadXmlFragmentFile( $target );
 
     $s = XmlFrag::listNodes( $s , XML_ELEMENT_NODE );
     $t = XmlFrag::listNodes( $t , XML_ELEMENT_NODE );

--- a/scripts/translation/qaxml-sync-attributes.php
+++ b/scripts/translation/qaxml-sync-attributes.php
@@ -43,9 +43,9 @@ foreach ( $oklist as $file )
     $match = array();
 
     foreach( $s as $v )
-        $match[$v] = array( 0 , 0 );
+        $match[$v] = [ 0 , 0 ];
     foreach( $t as $v )
-        $match[$v] = array( 0 , 0 );
+        $match[$v] = [ 0 , 0 ];
 
     foreach( $s as $v )
         $match[$v][0] += 1;

--- a/scripts/translation/qaxml-sync-entities.php
+++ b/scripts/translation/qaxml-sync-entities.php
@@ -1,0 +1,58 @@
+<?php /*
++----------------------------------------------------------------------+
+| Copyright (c) 1997-2025 The PHP Group                                |
++----------------------------------------------------------------------+
+| This source file is subject to version 3.01 of the PHP license,      |
+| that is bundled with this package in the file LICENSE, and is        |
+| available through the world-wide-web at the following url:           |
+| https://www.php.net/license/3_01.txt.                                |
+| If you did not receive a copy of the PHP license and are unable to   |
+| obtain it through the world-wide-web, please send a note to          |
+| license@php.net, so we can mail you a copy immediately.              |
++----------------------------------------------------------------------+
+| Authors:     André L F S Bacci <ae php.net>                          |
++----------------------------------------------------------------------+
+
+# Description
+
+Compare XML entities usage between two XML leaf/fragment files.       */
+
+require_once __DIR__ . '/libqa/all.php';
+
+$ignore = new OutputIgnore( $argv ); // always first, may exit.
+$list = SyncFileList::load();
+
+foreach ( $list as $file )
+{
+    $source = $file->sourceDir . '/' . $file->file;
+    $target = $file->targetDir . '/' . $file->file;
+    $output = new OutputBuffer( "# qaxml.e" , $target , $ignore );
+
+    [ $_ , $s , $_ ] = XmlFrag::loadXmlFragmentFile( $source );
+    [ $_ , $t , $_ ] = XmlFrag::loadXmlFragmentFile( $target );
+
+    if ( implode( "\n" , $s ) == implode( "\n" , $t ) )
+        continue;
+
+    $match = array();
+
+    foreach( $s as $v )
+        $match[$v] = array( 0 , 0 );
+    foreach( $t as $v )
+        $match[$v] = array( 0 , 0 );
+
+    foreach( $s as $v )
+        $match[$v][0] += 1;
+    foreach( $t as $v )
+        $match[$v][1] += 1;
+
+    foreach( $match as $k => $v )
+    {
+        if ( $v[0] == $v[1] )
+            continue;
+
+        $output->addDiff( $k , $v[0] , $v[1] );
+    }
+
+    $output->print();
+}

--- a/scripts/translation/qaxml-sync-entities.php
+++ b/scripts/translation/qaxml-sync-entities.php
@@ -37,9 +37,9 @@ foreach ( $list as $file )
     $match = array();
 
     foreach( $s as $v )
-        $match[$v] = array( 0 , 0 );
+        $match[$v] = [ 0 , 0 ];
     foreach( $t as $v )
-        $match[$v] = array( 0 , 0 );
+        $match[$v] = [ 0 , 0 ];
 
     foreach( $s as $v )
         $match[$v][0] += 1;
@@ -50,7 +50,6 @@ foreach ( $list as $file )
     {
         if ( $v[0] == $v[1] )
             continue;
-
         $output->addDiff( $k , $v[0] , $v[1] );
     }
 


### PR DESCRIPTION
This tool check for XML entity usage between doc-en and translations. This is particularly important in the case of file-entities, where mismatchs almost always cause build failures.