### PR TITLE
Fix unstable add/del ignores

### DIFF
--- a/scripts/translation/libqa/OutputBuffer.php
+++ b/scripts/translation/libqa/OutputBuffer.php
@@ -26,7 +26,6 @@ class OutputBuffer
     private array  $footer = [];
 
     private OutputIgnore $ignore;
-    private string $options;
 
     public int $printCount = 0;
 
@@ -37,7 +36,6 @@ class OutputBuffer
         $this->header = $header . ": " . $filename . "\n\n";
         $this->filename = $filename;
         $this->ignore = $ignore;
-        $this->options = implode( " " , $ignore->argv->residual() );
     }
 
     public function add( string $text )
@@ -88,14 +86,14 @@ class OutputBuffer
         if ( count( $this->matter ) == 0 && count( $this->footer ) == 0 )
             return;
 
+        $this->printCount++;
+
         $hashFile = hash( "crc32b" , $this->filename );
         $hashHead = $this->hash( false );
         $hashFull = $this->hash( true );
 
         if ( $this->ignore->shouldIgnore( $this , $hashFile , $hashHead , $hashFull ) )
             return;
-
-        $this->printCount++;
 
         print $this->header;
 
@@ -142,7 +140,8 @@ class OutputBuffer
 
     private function hash( bool $withContents ) : string
     {
-        $text = $this->header . $this->options;
+        $text = $this->header;
+        $text .= implode( "" , array_filter( $this->ignore->argvRest ) );
         if ( $withContents )
             $text .= implode( "" , $this->matter );
         $text = str_replace( " " , "" , $text );

--- a/scripts/translation/libqa/OutputIgnore.php
+++ b/scripts/translation/libqa/OutputIgnore.php
@@ -21,15 +21,17 @@ ignored outputs with these commands.                                  */
 class OutputIgnore
 {
     private string $filename = ".qaxml.ignores";
-    private string $argv0 = "";
 
-    public bool $appendIgnoreCommands = true;
     public ArgvParser $argv;
+    public string $argvZero = "";
+    public array  $argvRest = [];
+    public bool $appendIgnoreCommands = true;
 
     public function __construct( ArgvParser $argv )
     {
         $this->argv = $argv;
-        $this->argv0 = escapeshellarg( $argv->consume( position: 0 ) );
+        $this->argvZero = escapeshellarg( $argv->consume( position: 0 ) );
+        $this->argvRest = $this->argv->residual();
 
         $item = $argv->consume( prefix: "--add-ignore=" );
 
@@ -94,7 +96,7 @@ class OutputIgnore
             $ret = true;
         else
             if ( $this->appendIgnoreCommands )
-                $output->addFooter( "  php {$this->argv0} --add-ignore=$active\n" );
+                $output->addFooter( "  php {$this->argvZero} --add-ignore=$active\n" );
 
         // --del-ignore command
 
@@ -102,7 +104,7 @@ class OutputIgnore
             foreach ( $marks as $mark )
                 if ( str_starts_with( $mark , $prefix ) )
                     if ( $mark != $active )
-                        $output->addFooter( "  php {$this->argv0} --del-ignore=$mark\n" );
+                        $output->addFooter( "  php {$this->argvZero} --del-ignore=$mark\n" );
 
         return $ret;
     }

--- a/scripts/translation/qaxml-tags.php
+++ b/scripts/translation/qaxml-tags.php
@@ -29,10 +29,7 @@ $argv->complete();
 if ( count( $tags ) == 1 && $tags[0] == "" )
     $tags = [];
 
-if ( $detail )
-    $ignore->appendIgnoreCommands = false;
-
-$list   = SyncFileList::load();
+$list = SyncFileList::load();
 
 foreach ( $list as $file )
 {
@@ -44,8 +41,8 @@ foreach ( $list as $file )
     {
         // "Simple" tag contents check, by inner text
 
-        [ $s , $_ , $_ ] = XmlFrag::loadXmlFragmentFile( $source );
-        [ $t , $_ , $_ ] = XmlFrag::loadXmlFragmentFile( $target );
+        [ $s ] = XmlFrag::loadXmlFragmentFile( $source );
+        [ $t ] = XmlFrag::loadXmlFragmentFile( $target );
 
         $s = XmlFrag::listNodes( $s , XML_ELEMENT_NODE );
         $t = XmlFrag::listNodes( $t , XML_ELEMENT_NODE );
@@ -86,8 +83,8 @@ foreach ( $list as $file )
 
         // "Complex" tag contents check, by inner XML
 
-        [ $s , $_ , $_ ] = XmlFrag::loadXmlFragmentFile( $source );
-        [ $t , $_ , $_ ] = XmlFrag::loadXmlFragmentFile( $target );
+        [ $s ] = XmlFrag::loadXmlFragmentFile( $source );
+        [ $t ] = XmlFrag::loadXmlFragmentFile( $target );
 
         $s = XmlFrag::listNodes( $s , XML_ELEMENT_NODE );
         $t = XmlFrag::listNodes( $t , XML_ELEMENT_NODE );
@@ -127,8 +124,8 @@ foreach ( $list as $file )
     {
         // Check tag count, not contents
 
-        [ $s , $_ , $_ ] = XmlFrag::loadXmlFragmentFile( $source );
-        [ $t , $_ , $_ ] = XmlFrag::loadXmlFragmentFile( $target );
+        [ $s ] = XmlFrag::loadXmlFragmentFile( $source );
+        [ $t ] = XmlFrag::loadXmlFragmentFile( $target );
 
         $s = XmlFrag::listNodes( $s , XML_ELEMENT_NODE );
         $t = XmlFrag::listNodes( $t , XML_ELEMENT_NODE );


### PR DESCRIPTION
Fix cases where different arguments would generate add/del ignore for the same ignore hashes.

Also fixes unstable ignores of `scripts/translation/qaxml-tags.php`, that have multi-stage output and ignores.