### PR TITLE
PhD stuff at end of `configure.php`

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -327,36 +327,6 @@ function generate_sources_file() // {{{
     }
 } // }}}
 
-function getFileModificationHistory(): array {
-    global $ac;
-
-    $lang_mod_file = (($ac['LANG'] !== 'en') ? ("{$ac['rootdir']}/{$ac['EN_DIR']}") : ("{$ac['rootdir']}/{$ac['LANGDIR']}")) . "/fileModHistory.php";
-    $doc_base_mod_file = __DIR__ . "/fileModHistory.php";
-
-    $history_file = null;
-    if (file_exists($lang_mod_file)) {
-        $history_file = include $lang_mod_file;
-        if (is_array($history_file)) {
-            echo 'Copying modification history file... ';
-            $isFileCopied = copy($lang_mod_file, $doc_base_mod_file);
-            echo $isFileCopied ? "done.\n" : "failed.\n";
-        } else {
-            echo "Corrupted modification history file found: $lang_mod_file \n";
-        }
-    } else {
-        echo "Modification history file $lang_mod_file not found.\n";
-    }
-
-    if (!is_array($history_file)) {
-        $history_file = [];
-        echo "Creating empty modification history file...";
-        file_put_contents($doc_base_mod_file, "<?php\n\nreturn [];\n");
-        echo "done.\n";
-    }
-
-    return $history_file;
-}
-
 if ( true ) # Initial clean up
 {
     $dir = escapeshellarg( __DIR__ );
@@ -782,11 +752,6 @@ if ($ac['SOURCES_FILE'] === 'yes') {
     generate_sources_file();
 }
 
-$history_file = [];
-if ($ac['HISTORY_FILE'] === 'yes') {
-    $history_file = getFileModificationHistory();
-}
-
 globbetyglob("{$ac['basedir']}/scripts", 'make_scripts_executable');
 
 
@@ -1135,6 +1100,52 @@ if ($dom->relaxNGValidate(RNG_SCHEMA_FILE)) {
 
     errors_are_bad(1); // Tell the shell that this script finished with an error.
 }
+
+// All PhD stuff, after XML validation
+
+phd_acronym();
+php_history();
+//phd_sources();
+//phd_version();
+
+function phd_acronym()
+{
+    //TODO: Move acronym.xml code here
+}
+
+function php_history()
+{
+    global $ac;
+    if ($ac['HISTORY_FILE'] !== 'yes')
+        return;
+
+    echo 'PhD history:';
+
+    $lang_mod_file = (($ac['LANG'] !== 'en') ? ("{$ac['rootdir']}/{$ac['EN_DIR']}") : ("{$ac['rootdir']}/{$ac['LANGDIR']}")) . "/fileModHistory.php";
+    $doc_base_mod_file = __DIR__ . "/fileModHistory.php";
+
+    $history_file = null;
+    if (file_exists($lang_mod_file)) {
+        $history_file = include $lang_mod_file;
+        if (is_array($history_file)) {
+            echo ' copy,';
+            $isFileCopied = copy($lang_mod_file, $doc_base_mod_file);
+            echo $isFileCopied ? "" : " failed,";
+        } else {
+            echo " corrupted file '$lang_mod_file,'";
+        }
+    } else {
+        echo " not found,";
+    }
+
+    if (!is_array($history_file)) {
+        $history_file = [];
+        echo " creating empty,";
+        file_put_contents($doc_base_mod_file, "<?php\n\nreturn [];\n");
+    }
+    echo " done.\n";
+}
+
 
 printf("\nAll good. Saved %s\n", basename($ac["OUTPUT_FILENAME"]));
 echo "All you have to do now is run 'phd -d {$mxml}'\n";

--- a/configure.php
+++ b/configure.php
@@ -819,7 +819,11 @@ function xinclude_residual_fixup( DOMDocument $dom )
     $nodes = xinclude_residual_list( $dom );
 
     if ( count( $nodes ) > 0 )
-        dom_saveload( $dom , $debugPath ); // preserve state
+    {
+        unset( $nodes );
+        dom_saveload( $dom , $debugPath );
+        $nodes = $nodes = xinclude_residual_list( $dom );
+    }
 
     $count = 0;
     $explain = false;

--- a/configure.php
+++ b/configure.php
@@ -25,7 +25,7 @@ ini_set( 'display_startup_errors' , 1 );
 error_reporting( E_ALL );
 ob_implicit_flush();
 
-echo "configure.php on PHP " . phpversion() . "\n\n";
+echo "configure.php on PHP " . phpversion() . ", libxml " . LIBXML_DOTTED_VERSION . "\n\n";
 
 // init_argv()
 // init_checks()
@@ -574,9 +574,6 @@ checkvalue($ac['PARTIAL']);
 
 checking('whether to enable detailed XML error messages');
 checkvalue($ac['DETAILED_ERRORMSG']);
-
-checking('libxml version');
-checkvalue(LIBXML_DOTTED_VERSION);
 
 checking('whether to enable detailed error reporting (may segfault)');
 checkvalue($ac['SEGFAULT_ERROR']);

--- a/configure.php
+++ b/configure.php
@@ -1108,30 +1108,6 @@ dom_saveload( $dom );   // idempotent path
 
 if ($dom->relaxNGValidate(RNG_SCHEMA_FILE)) {
     echo "done.\n";
-    printf("\nAll good. Saved %s\n", basename($ac["OUTPUT_FILENAME"]));
-    echo "All you have to do now is run 'phd -d {$mxml}'\n";
-    echo "If the script hangs here, you can abort with ^C.\n";
-    echo <<<CAT
-         _ _..._ __
-        \)`    (` /
-         /      `\
-        |  d  b   |
-        =\  Y    =/--..-="````"-.
-          '.=__.-'               `\
-             o/                 /\ \
-              |                 | \ \   / )
-               \    .--""`\    <   \ '-' /
-              //   |      ||    \   '---'
-         jgs ((,,_/      ((,,___/
-
-
-CAT;
-
-    if (function_exists('proc_nice') && !is_windows()) {
-        echo " (Run `nice php $_SERVER[SCRIPT_NAME]` next time!)\n";
-    }
-
-    exit(0); // Tell the shell that this script finished successfully.
 } else {
     echo "failed.\n";
     echo "\nThe document didn't validate\n";
@@ -1159,3 +1135,28 @@ CAT;
 
     errors_are_bad(1); // Tell the shell that this script finished with an error.
 }
+
+printf("\nAll good. Saved %s\n", basename($ac["OUTPUT_FILENAME"]));
+echo "All you have to do now is run 'phd -d {$mxml}'\n";
+echo "If the script hangs here, you can abort with ^C.\n";
+echo <<<CAT
+         _ _..._ __
+        \)`    (` /
+         /      `\
+        |  d  b   |
+        =\  Y    =/--..-="````"-.
+          '.=__.-'               `\
+             o/                 /\ \
+              |                 | \ \   / )
+               \    .--""`\    <   \ '-' /
+              //   |      ||    \   '---'
+         jgs ((,,_/      ((,,___/
+
+
+CAT;
+
+if (function_exists('proc_nice') && !is_windows()) {
+    echo " (Run `nice php $_SERVER[SCRIPT_NAME]` next time!)\n";
+}
+
+exit(0); // Tell the shell that this script finished successfully.


### PR DESCRIPTION
This PR move all generation of PhD specific files to the end of `configure.php`, in particular, to after `manual.xml` validation, so the "time to validate" and "time to error" is vastly reduced on machines without SSD.

Also, this empathizes that these generated files are not relevant for `manual.xml` validation or generation, and so testing can concentrate on these functions alone.

Unrelated, but... time to remove the mention of `nice` in final messages?