### PR TITLE
Post check individual XML files for know issues

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -720,7 +720,26 @@ else
 {
     echo "failed.\n";
     print_xml_errors();
+    individual_xml_broken_check();
     errors_are_bad(1);
+}
+
+function individual_xml_broken_check()
+{
+    $cmd = array();
+    $cmd[] = $GLOBALS['ac']['PHP'];
+    $cmd[] = __DIR__ . "/scripts/broken.php";
+    $cmd[] = $GLOBALS['ac']['LANG'];
+    foreach ( $cmd as & $part )
+        $part = escapeshellarg( $part );
+    $ret = 0;
+    $cmd = implode( ' ' , $cmd );
+    passthru( $cmd , $ret );
+    if ( $ret != 0 )
+    {
+        echo "doc-base/scripts/broken.php FAILED.\n";
+        exit( 1 );
+    }
 }
 
 echo "Running XInclude/XPointer... ";
@@ -1171,8 +1190,5 @@ echo <<<CAT
 
 CAT;
 
-if (function_exists('proc_nice') && !is_windows()) {
-    echo " (Run `nice php $_SERVER[SCRIPT_NAME]` next time!)\n";
-}
-
-exit(0); // Tell the shell that this script finished successfully.
+individual_xml_broken_check();
+exit(0); // Finished successfully.

--- a/configure.php
+++ b/configure.php
@@ -850,8 +850,11 @@ function xinclude_residual_fixup( DOMDocument $dom )
     foreach( $nodes as $node )
     {
         if ( $count === 0 )
-            echo "\nFailed XInclude, inspect {$debugFile} for context:\n";
-        echo "  {$node->getAttribute("xpointer")}\n";
+        {
+            echo "\nFailed XIncludes, manual parts will be missing.";
+            echo " Inspect {$debugFile} for context. Failed targets are:\n";
+        }
+        echo "- {$node->getAttribute("xpointer")}\n";
         $count++;
 
         $fixup = null;

--- a/scripts/broken.php
+++ b/scripts/broken.php
@@ -190,7 +190,6 @@ function autofix_dos2unix( string $filename )
     if ( $GLOBALS['dos2unix'] )
     {
         $cmd = "dos2unix -r " . escapeshellarg( $filename );
-        echo $cmd;
         system( $cmd );
         echo "\n";
     }

--- a/scripts/broken.php
+++ b/scripts/broken.php
@@ -96,7 +96,7 @@ function testFile( string $filename , bool $fragment = false )
         echo "Wrong XML file:\n";
         echo "  Issue: XML file with BOM. Several tools may misbehave.\n";
         echo "  Path:  $filename\n";
-        echo "  Hint:  You can try autofix this with --dos2unix option.\n";
+        echo "  Hint:  You can try autofix this with 'doc-base/scripts/broken.php --dos2unix langdir'.\n";
         echo "\n";
         autofix_dos2unix( $filename );
     }
@@ -106,7 +106,7 @@ function testFile( string $filename , bool $fragment = false )
         echo "Wrong XML file:\n";
         echo "  Issue: XML file contains \\r. Several tools may misbehave.\n";
         echo "  Path:  $filename\n";
-        echo "  Hint:  You can try autofix this with --dos2unix option.\n";
+        echo "  Hint:  You can try autofix this with 'doc-base/scripts/broken.php --dos2unix langdir'.\n";
         echo "\n";
         autofix_dos2unix( $filename );
     }


### PR DESCRIPTION
This is a PR that increments warnings in almost all translations, so I ask for comments for a longer time, before commiting.

With this PR, when a `configure.php` fails on the first XML loading, it will run `scripts/broken.php`, to help debug issues that are present in one individual file.

This PR **also** will run `scripts/broken.php` as the last step of a *successful* `configure.php` run, to report "invisible" issues that may be accumulating, even if the language manual builds and validates.

The warnings are:

* `Error: Opening and ending tag mismatch:`: Yes, there are XML files that are just plain broken, in some repositories.

* `Error: Start tag expected, '<' not found`: These are mostly files named `entities.foo.bar.xml`. They are auto generated, and should not exist in translations. Remove these files.
* `XML file with BOM. Several tools may misbehave.`: Files with BOM exercise different code paths inside libxml, to the point of generating unrelated warnings.
* `Error: Input is not proper UTF-8, indicate encoding !`: Files not encoded as UTF-8.
* `Namespace prefix xlink for href on link is not defined`: Mostly harmless, but fixing this issues helps running libxml with more strict options. Also individual XML files become more "correct" with proper name spaced prefixes.
*  `Error: Extra content at the end of the document / Hint:  Dir is marked with .xmlfragmentdir on doc-en? If not, check entity references.` This warning has two false positives in the manual, that can be disabled by touching and committing an `.xmlfragmentdir` file on the directory. This directory will soon be moved/erased after "XML Entities" project advances, so it may be worth it to disable this warning in the meantime.
* `XML file contains \r. Several tools may misbehave.`: The most common issue. Only shows when running on Linux and similar OSes. All languages in manual converged to a `\n` only EOL, at git repository level. Several userland tools only care for `\n` and will severely misbehave when dealing with text files that contain `\r`. Simply running `dos2unix` on these files fixes the issue.

I would like to hear comments for all points if possible, but more importantly on the last point, the `\r` one, as it is by far the most frequent one, as it will generate pages of warnings in some translations, if/when this PR is merged.