### PR TITLE
Add missing ext/operator documentation

### DIFF
--- a/entities/global.ent
+++ b/entities/global.ent
@@ -371,6 +371,7 @@
 <!ENTITY url.openssl.ciphers.mozilla "https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_Ciphersuite">
 <!ENTITY url.openssl.security-level "https://docs.openssl.org/master/man3/SSL_CTX_set_security_level/">
 <!ENTITY url.openssl.config "https://docs.openssl.org/master/man5/config/">
+<!ENTITY url.operator.source "https://github.com/jb-lopez/pecl-php-operator/">
 <!ENTITY url.oracle.instant.client "https://www.oracle.com/database/technologies/instant-client.html">
 <!ENTITY url.oracle.oic.connect "https://www.oracle.com/pls/topic/lookup?ctx=dblatest&amp;id=GUID-E5358DEA-D619-4B7B-A799-3D2F802500F1">
 <!ENTITY url.oracle.drcp.configure "https://docs.oracle.com/en/database/oracle/oracle-database/23/jjdbc/database-resident-connection-pooling.html">

--- a/manual.xml
+++ b/manual.xml
@@ -137,6 +137,7 @@
    &reference.errorfunc.book;
    &reference.ffi.book;
    &reference.opcache.book;
+   &reference.operator.book;
    &reference.outcontrol.book;
    &reference.info.book;
    &reference.phpdbg.book;


### PR DESCRIPTION
This pull request is to add the missing documentation for the PECL operator extension. I have taken over as the lead maintainer for that extension, but this is my first contribution to the PHP documentation. There is a companion pull request to `doc-en` that goes with one and requires this one. https://github.com/php/doc-en/pull/4669