### PR TITLE
Disable doc-ro in languages.php and document core.autocrlf usage

### DIFF
--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -1,6 +1,6 @@
 # Setting up a local development environment
 
-This guide assumes that you are comfortable working with on the
+This guide assumes that you are comfortable working on the
 command line with tools like Git.
 
 There are instructions for building [with Docker](#with-docker) or
@@ -10,10 +10,10 @@ will be building with a version of PHP that is known to work.
 
 When working with multiple translations, or working on changes that may
 also require changing files in the `doc-base` or `phd` repositories, the
-suggested way to organize the local enviroment is to clone repositories
+suggested way to organize the local environment is to clone repositories
 into a single `phpdoc` directory, and for individual languages to be cloned
 into directories named `{LANG}` instead of `doc-{LANG}` as they are named
-on GitHub.
+on GitHub. See `doc-base/languages.php` script to automate this process.
 
 <a name="with-docker"></a>
 ## Building with make and Docker
@@ -38,7 +38,7 @@ building, otherwise the latest revision of those repositories from GitHub
 will be built into the Docker image used.
 
 To force the Docker image used for building to itself be rebuilt, run
-`make -B build`, otherwise the `Makefile` will only build it if does not
+`make -B build`, otherwise the `Makefile` will only build it if it does not
 already exist.
 
 The web version of the documentation with `make php` and the output will
@@ -102,4 +102,35 @@ To build the version for the website (with a [local web setup](local-web-setup.m
 ```sh
 $ php phd/render.php --docbook doc-base/.manual.xml --package PHP --format php
 $ open https://localhost:8080/manual/en/
+```
+
+<a name="windows-eol"></a>
+## Translating on Windows
+
+When working on Windows, try to use text editors that preserve the end
+of line mark as `U+000A LINE FEED (LF)` only. If it's not possible,
+you may issue the commands below to instruct `git` in transforming
+the files in your local clone to use the Windows native end of line
+mark:
+
+```
+cd LANG
+git config core.autocrlf true
+git add --renormalize .
+git status
+```
+
+If the last comment above outputs no files, then the process works,
+and you can start translating.
+
+If the last command above shows a list of files, something went wrong,
+because these listed files will be changed at *repository level*
+in the next commit. There should be *none*. If any files are listed,
+revert the changes with commands below and open an issue on
+`doc-base` repository.
+
+```
+git config --unset core.autocrlf
+git add --renormalize .
+git status
 ```

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -131,6 +131,6 @@ revert the changes with commands below and open an issue on
 
 ```
 git config --unset core.autocrlf
-git add --renormalize .
+git reset
 git status
 ```

--- a/languages.php
+++ b/languages.php
@@ -16,8 +16,8 @@
 +------------------------------------------------------------------------------+
 */
 
-//     dir     manual  revcheck  cloneUrl                          label
-
+// Languages repositories on GitHub
+//    dir     manual  revcheck  cloneUrl                          label
 lang( "de"    , true  , true  , "git@github.com:php/doc-de.git" , "German" );
 lang( "en"    , true  , false , "git@github.com:php/doc-en.git" , "English" );
 lang( "es"    , true  , true  , "git@github.com:php/doc-es.git" , "Spanish" );
@@ -30,6 +30,10 @@ lang( "ru"    , true  , true  , "git@github.com:php/doc-ru.git" , "Russian" );
 lang( "tr"    , true  , true  , "git@github.com:php/doc-tr.git" , "Turkish" );
 lang( "uk"    , true  , true  , "git@github.com:php/doc-uk.git" , "Ukrainian" );
 lang( "zh"    , true  , true  , "git@github.com:php/doc-zh.git" , "Chinese (Simplified)" );
+
+// Inactive languages, per https://www.php.net/manual/help-translate.php
+// - Polish
+// - Romanian / ro / git@github.com:php/doc-pl.git
 
 if ( count( $argv ) == 1 )
     print_usage();

--- a/languages.php
+++ b/languages.php
@@ -26,7 +26,6 @@ lang( "it"    , true  , true  , "git@github.com:php/doc-it.git" , "Italian" );
 lang( "ja"    , true  , true  , "git@github.com:php/doc-ja.git" , "Japanese" );
 lang( "pl"    , false , true  , "git@github.com:php/doc-pl.git" , "Polish" );
 lang( "pt_BR" , true  , true  , "git@github.com:php/doc-pt_br.git" , "Brazilian Portuguese" );
-lang( "ro"    , false , true  , "git@github.com:php/doc-ro.git" , "Romanian" );
 lang( "ru"    , true  , true  , "git@github.com:php/doc-ru.git" , "Russian" );
 lang( "tr"    , true  , true  , "git@github.com:php/doc-tr.git" , "Turkish" );
 lang( "uk"    , true  , true  , "git@github.com:php/doc-uk.git" , "Ukrainian" );

--- a/languages.php
+++ b/languages.php
@@ -26,14 +26,11 @@ lang( "it"    , true  , true  , "git@github.com:php/doc-it.git" , "Italian" );
 lang( "ja"    , true  , true  , "git@github.com:php/doc-ja.git" , "Japanese" );
 lang( "pl"    , false , true  , "git@github.com:php/doc-pl.git" , "Polish" );
 lang( "pt_BR" , true  , true  , "git@github.com:php/doc-pt_br.git" , "Brazilian Portuguese" );
+lang( "ro"    , false , false , "git@github.com:php/doc-ro.git" , "Romanian" );
 lang( "ru"    , true  , true  , "git@github.com:php/doc-ru.git" , "Russian" );
 lang( "tr"    , true  , true  , "git@github.com:php/doc-tr.git" , "Turkish" );
 lang( "uk"    , true  , true  , "git@github.com:php/doc-uk.git" , "Ukrainian" );
 lang( "zh"    , true  , true  , "git@github.com:php/doc-zh.git" , "Chinese (Simplified)" );
-
-// Inactive languages, per https://www.php.net/manual/help-translate.php
-// - Polish
-// - Romanian / ro / git@github.com:php/doc-pl.git
 
 if ( count( $argv ) == 1 )
     print_usage();
@@ -73,8 +70,11 @@ USAGE;
 
 function lang( string $code , bool $manual , bool $revcheck , string $cloneUrl , string $label )
 {
-    $lang = new Lang( $code , $manual , $revcheck , $cloneUrl , $label );
-    Conf::$knowLangs[ $code ] = $lang;
+    if ( $manual || $revcheck )
+    {
+        $lang = new Lang( $code , $manual , $revcheck , $cloneUrl , $label );
+        Conf::$knowLangs[ $code ] = $lang;
+    }
 }
 
 class Conf


### PR DESCRIPTION
`doc-ro` appears to be abandoned, and is marked inactive on https://www.php.net/manual/help-translate.php .

Also, document usage of `git` `core-autocrlf` option to avoid future `\r\n` files on document repositories.

Aside, the link for Polish SVN archive on link above is broken, because `http://docs.php.net/manual/pl` does not exist.

These are minor changes, and I plan to merge it on few weeks. I would like comments (and testing) if the suggested solution for Windows users.