### PR TITLE
added &appendices.examples; page reference

### DIFF
--- a/manual.xml
+++ b/manual.xml
@@ -449,6 +449,7 @@
   &appendices.tokens;
   &appendices.userlandnaming;
   &appendices.about;
+  &appendices.examples;
   &appendices.license;
   &global.function-index;
   <appendix xmlns="http://docbook.org/ns/docbook" xml:id="doc.changelog">


### PR DESCRIPTION
We should add [About manual examples](https://github.com/php/doc-en/blob/bce2cb849721c70737eb32ce958131e22677770c/appendices/examples.xml) page to [Appendices](https://www.php.net/manual/en/appendices.php) index.
 