### PR TITLE
Fix broken ICU link in intl.configuration documentation

### DIFF
--- a/entities/global.ent
+++ b/entities/global.ent
@@ -172,7 +172,7 @@
 <!ENTITY url.icu.home "https://icu.unicode.org/">
 <!ENTITY url.icu.locale.guide "https://unicode-org.github.io/icu/userguide/locale/">
 <!ENTITY url.icu.locale.api "https://unicode-org.github.io/icu-docs/apidoc/dev/icu4c/uloc_8h.html">
-<!ENTITY url.icu.locales "https://icu4c-demos.unicode.org/icu-bin/locexp">
+<!ENTITY url.icu.locales "https://unicode-org.github.io/icu/userguide/locale/">
 <!ENTITY url.icu.msgformat "https://unicode-org.github.io/icu/userguide/format_parse/messages/">
 <!ENTITY url.icu.normalization.guide "https://unicode-org.github.io/icu/userguide/transforms/normalization/">
 <!ENTITY url.icu.normalization.api "https://unicode-org.github.io/icu-docs/apidoc/dev/icu4c/unorm_8h.html">


### PR DESCRIPTION
The old ICU Locale Explorer link (https://icu4c-demos.unicode.org/icu-bin/locexp) is no longer available.

Replaced it with the official and maintained ICU documentation page: https://unicode-org.github.io/icu/userguide/locale/

This page provides up-to-date information about locale handling in ICU,  which is more relevant and stable for the intl extension documentation.

Issue: https://github.com/php/doc-en/issues/4884