### PR TITLE
Do not check entities files for XML validity

### DIFF
--- a/scripts/broken.php
+++ b/scripts/broken.php
@@ -177,7 +177,8 @@ function testDir( string $dir )
             continue;
         }
 
-        if ( str_ends_with( $fullpath , ".xml" ) )
+        if (!basename( $fullpath ) === "entities."
+            && str_ends_with( $fullpath , ".xml" ) )
             testFile( $fullpath , $fragment );
     }
 


### PR DESCRIPTION
Do not check `entities` files for XML validity as these are never valid on their own. 