### PR TITLE
Deprecated backtick operator with shell_exec() for PHP 8.5

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -587,7 +587,7 @@ $output = "";
 foreach ( $repos as $name => $path )
 {
     $path = escapeshellarg( $path );
-    $branch = trim( `git -C $path rev-parse --abbrev-ref HEAD` );
+    $branch = trim(shell_exec("git -C $path rev-parse --abbrev-ref HEAD"));
     $suffix = $branch == "master" ? "" : " (branch $branch)";
     $output .= str_pad( "$name:" , 10 );
     $output .= rtrim(shell_exec("git -C $path rev-parse HEAD") ?? "") . "$suffix ";


### PR DESCRIPTION
This PR replaces the use of the backtick operator (`` `cmd` ``), which is officially deprecated as of PHP 8.5.

Reference:
- RFC: https://wiki.php.net/rfc/deprecations_php_8_5
- https://github.com/php/php-src/commit/3d9d68e1cacf8d185de6281bfec058b22e3094f8

The affected calls fetch Git metadata during the build process. Using `shell_exec()` is semantically identical and avoids E_DEPRECATED notices on PHP 8.5.

Behavior and output remain unchanged. Tested with PHP 8.3, 8.4 and 8.5.