### PR TITLE
Litespeed: Revert reference to new book (#287)

### DIFF
--- a/manual.xml
+++ b/manual.xml
@@ -346,7 +346,6 @@
   <set xml:id="refs.utilspec.server">
    <title>&ServerSpecificExtensions;</title>
    &reference.apache.book;
-   &reference.litespeed.book;
    &reference.fpm.book;
   </set>
 


### PR DESCRIPTION
Reverts php/doc-base#287

It breaks existing integrations. Should add it back once merge is fully ready.