### PR TITLE
Add QoS (Quality of Service) acronym

### DIFF
--- a/entities/acronyms.xml
+++ b/entities/acronyms.xml
@@ -402,6 +402,12 @@
    </listitem>
   </varlistentry>
   <varlistentry>
+   <term>QoS</term>
+   <listitem>
+    <simpara>Quality of Service</simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
    <term>RGB</term>
    <listitem>
     <simpara>Red-Green-Blue</simpara>


### PR DESCRIPTION
Adds the `QoS` acronym (Quality of Service) so it can be used with the `<acronym>` tag, notably in the new pcntl QoS class functions.