### PR TITLE
Optimize xinclude_run_byid by caching elements by xml:id

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -704,17 +704,25 @@ function xinclude_run_byid( DOMDocument $dom )
     // so we need to *simulate* its *recursive* nature here.
 
     $total = 0;
+    $xpath = new DOMXPath( $dom );
+    $xpath->registerNamespace( "xi" , "http://www.w3.org/2001/XInclude" );
+
+    // Resolve xpointers via a precomputed map; on duplicate xml:ids, first wins.
+    // Avoids quadratic tree walks (~ 90% performance gain).
+    $byId = [];
+    foreach( $xpath->query( "//*[@xml:id]" ) as $node ) {
+        $byId[$node->getAttribute("xml:id")] ??= $node;
+    }
+
     for( $run = 0 ; $run < 10 ; $run++ )
     {
-        $xpath = new DOMXPath( $dom );
-        $xpath->registerNamespace( "xi" , "http://www.w3.org/2001/XInclude" );
         $xincludes = $xpath->query( "//xi:include" );
 
         $changed = false;
         foreach( $xincludes as $xinclude )
         {
             $xpointer = $xinclude->getAttribute( "xpointer" );
-            $target = $xinclude->ownerDocument->getElementById( $xpointer );
+            $target = $byId[ $xpointer ] ?? null;
 
             if ( $target == null )
                 continue;


### PR DESCRIPTION
Resolve xpointers via a precomputed map; on duplicate xml:ids, first wins.
Avoids quadratic tree walks (~ 90% performance gain).

On my local machine, `xinclude_run_byid` took 22 seconds to compute. With this change it's down to 0.24s.
Overall `configure.php` went down from 29 seconds to just 7 seconds.
