### PR TITLE
Raise JAXP entity size limit for jing validation

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -982,7 +982,7 @@ function xml_validate_jing()
     $out = null;
     $ret = null;
     $schema = RNG_SCHEMA_FILE;
-    $cmdJing = "java -jar {$srcdir}/docbook/jing.jar {$schema} {$idempath}";
+    $cmdJing = "java -Djdk.xml.totalEntitySizeLimit=300000 -jar {$srcdir}/docbook/jing.jar {$schema} {$idempath}";
     exec( $cmdJing , $out , $ret );
 
     if ( $ret == 0 )


### PR DESCRIPTION
According to Philip, there are around 240.925 entities. Which I have verified myself as well.
Some configurations have a lower limit set. For that reason it is good that we set the limit to 300.000 avoid issues during build time.

```
Validating temp/manual.xml (jing)... failed.
/path/to/phpdoc/doc-base/temp/manual.xml:1954:104: fatal: JAXP00010004: The accumulated size of entities is "100,007" that exceeded the "100,000" limit set by "jaxp.properties".
```

