### PR TITLE
Remove skeleton comments

### DIFF
--- a/skeletons/book.xml
+++ b/skeletons/book.xml
@@ -3,14 +3,12 @@
  <title>Long title of extension</title>
  <titleabbrev>Extname</titleabbrev>
 
- <!-- {{{ preface -->
  <preface xml:id="intro.extname">
   &reftitle.intro;
   <simpara>
    Extension introduction.
   </simpara>
  </preface>
- <!-- }}} -->
 
  &reference.extname.setup;
  &reference.extname.constants;

--- a/skeletons/classname.xml
+++ b/skeletons/classname.xml
@@ -5,19 +5,16 @@
  
  <partintro>
 
-  <!-- {{{ ClassName intro -->
   <section xml:id="classname.intro">
    &reftitle.intro;
    <simpara>
     Description of the class.
    </simpara>
   </section>
-  <!-- }}} -->
 
   <section xml:id="classname.synopsis">
    &reftitle.classsynopsis;
 
-   <!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <classname>ClassName</classname>
@@ -90,7 +87,6 @@
      <xi:fallback/>
     </xi:include>
    </classsynopsis>
-   <!-- }}} -->
 
   </section>
 

--- a/skeletons/exceptionname.xml
+++ b/skeletons/exceptionname.xml
@@ -5,19 +5,16 @@
  
  <partintro>
  
-<!-- {{{ ExceptionName intro -->
   <section xml:id="exceptionname.intro">
    &reftitle.intro;
    <simpara>
     Description of the exception.
    </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="exceptionname.synopsis">
    &reftitle.classsynopsis;
 
-   <!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <classname>ExceptionName</classname>

--- a/skeletons/method.xml
+++ b/skeletons/method.xml
@@ -131,7 +131,7 @@ Procedural synopsis goes after OOP synopsis.
 <![CDATA[
 <?php
 if ($anexample === true) {
-    echo 'Use the PEAR Coding standards';
+    echo 'Use the PER Coding standards';
 }
 if ($thereisoutput === 'and it is multiple lines') {
     echo 'Use a screen like we did below';

--- a/skeletons/method.xml
+++ b/skeletons/method.xml
@@ -131,7 +131,7 @@ Procedural synopsis goes after OOP synopsis.
 <![CDATA[
 <?php
 if ($anexample === true) {
-    echo 'Use the PER Coding standards';
+    echo 'Use the latest PHP-FIG PER Coding style for PHP code examples: https://www.php-fig.org/per/coding-style/';
 }
 if ($thereisoutput === 'and it is multiple lines') {
     echo 'Use a screen like we did below';

--- a/skeletons/setup.xml
+++ b/skeletons/setup.xml
@@ -3,35 +3,27 @@
  &reftitle.setup;
 
  <!-- Remove sections which are useless -->
- <!-- {{{ Requirements -->
  <section xml:id="extname.requirements">
   &reftitle.required;
   &no.requirement;
  </section>
- <!-- }}} -->
 
- <!-- {{{ Installation -->
  <section xml:id="extname.installation">
   &reftitle.install;
   &no.install;
  </section>
  <!-- or &reference.extname.entities.configure; -->
- <!-- }}} -->
 
- <!-- {{{ Configuration -->
  <section xml:id="extname.configuration">
   &reftitle.runtime;
   &no.config;
  </section>
  <!-- or &reference.extname.entities.ini; -->
- <!-- }}} -->
 
- <!-- {{{ Resources -->
  <section xml:id="extname.resources">
   &reftitle.resources;
   &no.resource;
  </section>
- <!-- }}} -->
 
 </chapter>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
In https://github.com/php/doc-en/pull/5630 we decided to remove these comments, and mention `PER` instead of `PECL`; this PR aligns the `doc-base` skeletons to that decision.

~~**Additionally**
I added todo markers to `PECL` references in the skeleton directory (second commit). Since `PECL` is deprecated in favour of `PIE`, we should think about what to do with these - I'd appreciate your input to that! Marked as draft for now -- before the merge the second comments should either be dropped, or a follow up commit be made for whatever you imagine to happen with the `PECL` mentions.~~