### PR TITLE
Added PECL todos for PR discussion

### DIFF
--- a/skeletons/configure.xml
+++ b/skeletons/configure.xml
@@ -4,7 +4,7 @@
 
  <!-- If the extension doesn't need to be installed (built-in extension) use this entity -->
  <!-- &no.install; -->
- <!-- There are various PECL related entities in language-snippets.ent -->
+ <!-- There are various PECL related entities in language-snippets.ent / todo: decide PECL removal -->
  <simpara>
   To enable extname support, configure PHP with 
   <option role="configure">theconfigoption</option>

--- a/skeletons/versions.xml
+++ b/skeletons/versions.xml
@@ -5,9 +5,9 @@
 <versions>
  <function name='foo' from='PHP 7 &gt;= 7.4.0, PHP 8'/>
  <function name='bar' from='PHP 8'/>
- <function name='baz' from='PECL extname &gt;= 0.4'/>
- <function name='quz' from='PECL extname 0.1-0.3' removed="PECL extname 0.3"/>
- <function name='classname::methodname' from='PECL extname &gt;= 1.1'/>
+ <function name='baz' from='PECL extname &gt;= 0.4'/><!--  / todo: decide PECL removal -->
+ <function name='quz' from='PECL extname 0.1-0.3' removed="PECL extname 0.3"/><!--  / todo: decide PECL removal -->
+ <function name='classname::methodname' from='PECL extname &gt;= 1.1'/><!--  / todo: decide PECL removal -->
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
I added todo markers to PECL references in the skeleton directory. Since PECL is deprecated in favour of PIE, we should think about what to do with these. Adding new docs for the deprecated  PECL should not happen.

This is marked as draft, and not supposed to be merged as is; purpose is to start a discussion about what to do.