### PR TITLE
Creates the do-not-translate mark

### DIFF
--- a/docs/editing.md
+++ b/docs/editing.md
@@ -38,6 +38,9 @@ Changes in the English version are eventually picked up by the translators.
 If a change doesn't affect translations (e.g. fixing a typo in English) then the
 commit message should start with `[skip-revcheck]`.
 
+Files that are not to be translated, or copied on translations, should include
+an `<?do-not-translate?>` mark.
+
 ## Validating your changes
 Every time you make changes to documentation sources (both English or translation),
 you have to validate your changes to ensure that the manual still builds without error.

--- a/scripts/broken.php
+++ b/scripts/broken.php
@@ -1,6 +1,6 @@
 <?php /*
 +----------------------------------------------------------------------+
-| Copyright (c) 1997-2025 The PHP Group                                |
+| Copyright (c) 1997-2026 The PHP Group                                |
 +----------------------------------------------------------------------+
 | This source file is subject to version 3.01 of the PHP license,      |
 | that is bundled with this package in the file LICENSE, and is        |
@@ -38,20 +38,28 @@ foreach( $argv as & $arg )
         $dos2unix = true;
         $arg = null;
     }
+    else
+        $arg = str_replace( '\\' , '/' , $arg );
 }
-$argv = array_filter( $argv );
+$paths = array_filter( $argv );
+if ( count( $paths) == 0 )
+    print_usage_exit();
 
-foreach( $argv as $arg )
+foreach( $paths as $path )
 {
-    if ( file_exists( $arg ) )
+    $dnt = true;
+    if ( $path == 'en' || str_ends_with( $path , '/en' ) )
+        $dnt = false;
+
+    if ( file_exists( $path ) )
     {
-        if ( is_file( $arg ) )
-            testFile( $arg );
-        if ( is_dir( $arg ) )
-            testDir( $arg );
+        if ( is_file( $path ) )
+            testFile( $path , $dnt );
+        if ( is_dir( $path ) )
+            testDir( $path , $dnt );
         continue;
     }
-    echo "Path does not exist: $arg\n";
+    echo "Path does not exist: $path\n";
 }
 
 function print_usage_exit( $cmd )
@@ -87,7 +95,7 @@ function setup( string & $prefix , string & $suffix , string & $extra )
     libxml_clear_errors();
 }
 
-function testFile( string $filename , bool $fragment = false )
+function testFile( string $filename , bool $checkDnt , bool $fragmentDir = false )
 {
     $contents = file_get_contents( $filename );
 
@@ -96,7 +104,7 @@ function testFile( string $filename , bool $fragment = false )
         echo "Wrong XML file:\n";
         echo "  Issue: XML file with BOM. Several tools may misbehave.\n";
         echo "  Path:  $filename\n";
-        echo "  Hint:  You can try autofix this with 'doc-base/scripts/broken.php --dos2unix langdir'.\n";
+        echo "  Hint:  You can try auto fix this with 'doc-base/scripts/broken.php --dos2unix langdir'.\n";
         echo "\n";
         autofix_dos2unix( $filename );
     }
@@ -106,7 +114,16 @@ function testFile( string $filename , bool $fragment = false )
         echo "Wrong XML file:\n";
         echo "  Issue: XML file contains \\r. Several tools may misbehave.\n";
         echo "  Path:  $filename\n";
-        echo "  Hint:  You can try autofix this with 'doc-base/scripts/broken.php --dos2unix langdir'.\n";
+        echo "  Hint:  You can try auto fix this with 'doc-base/scripts/broken.php --dos2unix langdir'.\n";
+        echo "\n";
+        autofix_dos2unix( $filename );
+    }
+
+    if ( $checkDnt && strpos( $contents , '<?do-not-translate?>' ) !== false )
+    {
+        echo "File marked do-not-translate in translation:\n";
+        echo "  Issue: Manual build may fail.\n";
+        echo "  Path:  $filename\n";
         echo "\n";
         autofix_dos2unix( $filename );
     }
@@ -121,7 +138,7 @@ function testFile( string $filename , bool $fragment = false )
     $doc->substituteEntities = false;
     libxml_use_internal_errors( true );
 
-    if ( $fragment )
+    if ( $fragmentDir )
         $contents = "<f>{$contents}</f>";
     $doc->loadXML( $contents );
 
@@ -152,18 +169,18 @@ function testFile( string $filename , bool $fragment = false )
     }
 }
 
-function testDir( string $dir )
+function testDir( string $dir , bool $checkDnt )
 {
     $dir = realpath( $dir );
     $files = scandir( $dir );
-    $fragment = false;
+    $fragmentDir = false;
     $subdirs = [];
 
     foreach( $files as $file )
     {
         if ( $file == ".xmlfragmentdir" )
         {
-            $fragment = true;
+            $fragmentDir = true;
             continue;
         }
         if ( $file[0] == "." )
@@ -178,11 +195,11 @@ function testDir( string $dir )
         }
 
         if ( str_ends_with( $fullpath , ".xml" ) )
-            testFile( $fullpath , $fragment );
+            testFile( $fullpath , $checkDnt , $fragmentDir );
     }
 
     foreach( $subdirs as $dir )
-        testDir( $dir );
+        testDir( $dir , $checkDnt );
 }
 
 function autofix_dos2unix( string $filename )

--- a/scripts/translation/lib/RevcheckIgnore.php
+++ b/scripts/translation/lib/RevcheckIgnore.php
@@ -1,7 +1,7 @@
 <?php
 /**
  *  +----------------------------------------------------------------------+
- *  | Copyright (c) 1997-2023 The PHP Group                                |
+ *  | Copyright (c) 1997-2026 The PHP Group                                |
  *  +----------------------------------------------------------------------+
  *  | This source file is subject to version 3.01 of the PHP license,      |
  *  | that is bundled with this package in the file LICENSE, and is        |
@@ -64,5 +64,12 @@ class RevcheckIgnore
 
         // At least, do not ignore
         return false;
+    }
+
+    public static function mark( $filename )
+    {
+        $contents = file_get_contents( $filename );
+        $skip = strpos( $contents , '<?do-not-translate?>' ) !== false;
+        return $skip;
     }
 }

--- a/scripts/translation/lib/RevcheckRun.php
+++ b/scripts/translation/lib/RevcheckRun.php
@@ -82,6 +82,9 @@ class RevcheckRun
 
             if ( $target == null )
             {
+                if ( RevcheckIgnore::mark( "{$this->sourceDir}/{$source->file}" ) )
+                    continue;
+
                 $source->status = RevcheckStatus::Untranslated;
                 $this->filesUntranslated[] = $source;
                 $this->addData( $source , null );


### PR DESCRIPTION
Updates the revcheck libraries to detect the `<?do-not-translate?>` marker in tracked files, allowing files to automatically declare that they are untranslatable and/or should not be copied into translations.

The `doc-base/scripts/broken.php` file was also modified along the same lines.

After this is merged, and DNT files are marked as so on `doc-en`, a lot of exceptional code can be removed from revcheck libs. This aligns in making `doc-base` more general, as it becomes less dependent on filename conventions, to facilitate the eventual splitting of external extensions manual from the language manual.

Reviews and comments welcome.

As this is a far reaching feature, plan to wait at least for two weeks before merging it,