### PR TITLE
Scan doc-contrib directory in file-entities generation

### DIFF
--- a/scripts/file-entities.php
+++ b/scripts/file-entities.php
@@ -88,6 +88,12 @@ echo "Running file-entities.php... ";
 $entities = [];
 $mixedCase = [];
 
+if ( is_dir( "$root/doc-contrib" ) )
+{
+    generate_file_entities( $root , "doc-contrib" );
+    generate_list_entities( $root , "doc-contrib" );
+}
+
 generate_file_entities( $root , "en" );
 generate_list_entities( $root , "en" );
 


### PR DESCRIPTION
Counterpart to the new [lacatoire/doc-contrib](https://github.com/lacatoire/doc-contrib) repository, implementing the accepted [RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third-party-code).

When a `doc-contrib/` directory exists alongside `en/` in the root, `file-entities.php` now scans it before `doc-en/`. Entities from `doc-en` override `doc-contrib` where both repositories define the same file, so migration is incremental: removing an extension from `doc-en` is sufficient to hand it off to `doc-contrib`.

The RFC covers a large set of extensions. php/doc-en#5665 tracks the first wave of candidates (seven long-unmaintained PECL extensions) to validate the handoff mechanism before broader migration.