### PR TITLE
Use a language directory's manual.xml when present

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -674,7 +674,19 @@ function dom_saveload( DOMDocument $dom , string $filename = "" ) : string
 echo "Creating monolithic temp/manual.xml... ";
 $dom = new DOMDocument();
 
-if ( dom_load( $dom , "{$ac['srcdir']}/{$ac["INPUT_FILENAME"]}" ) )
+// A language directory may ship its own manual.xml to build a self-contained
+// manual (e.g. the third-party extension manual) that references only its own
+// books, instead of the main manual skeleton in doc-base. When absent, the
+// default doc-base manual.xml is used, so existing builds are unaffected.
+$input_manual = "{$ac['srcdir']}/{$ac["INPUT_FILENAME"]}";
+$lang_manual  = "{$LANGDIR}/{$ac["INPUT_FILENAME"]}";
+if ( file_exists( $lang_manual ) )
+{
+    echo "using {$ac['LANG']}/{$ac["INPUT_FILENAME"]}... ";
+    $input_manual = $lang_manual;
+}
+
+if ( dom_load( $dom , $input_manual ) )
 {
     dom_saveload( $dom ); // correct file/line/column on error messages
     echo " done.\n";


### PR DESCRIPTION
When a language directory contains its own `manual.xml`, `configure.php` now builds from it instead of the main manual skeleton in doc-base. When absent, the doc-base `manual.xml` is used as before, so all existing builds (en and translations) are byte-for-byte unaffected.

This lets a manual be fully self-contained in its own repository: it can declare its own entity wiring and reference only its own books. Motivation is the third-party extension manual split ([lacatoire/doc-contrib](https://github.com/lacatoire/doc-contrib)), where reusing the main skeleton fails because it references ~160 core books the contrib repo does not provide. Supersedes the file-entities scanning approach discussed in #320.
