### PR TITLE
Fix incomplete entity reference work around.

### DIFF
--- a/scripts/text-entities.php
+++ b/scripts/text-entities.php
@@ -329,7 +329,7 @@ function loadEntityGroup( string $path )
 {
     $path = realpath( $path );
     $text = file_get_contents( $path );
-    $text = str_replace( "&" , "&amp;" , $text );
+    $text = str_replace( '&' , '&amp;' , $text );
 
     $dom = new DOMDocument( '1.0' , 'utf8' );
     if ( ! $dom->loadXML( $text ) )
@@ -371,6 +371,7 @@ function loadEntityGroup( string $path )
         $text = "";
         foreach( $other->childNodes as $node )
             $text .= $other->saveXML( $node );
+        $text = str_replace( '&amp;' , '&' , $text );
 
         Entities::put( $path , $name , $text , $unique , $remove );
     }


### PR DESCRIPTION
Noted on doc ext/contrib efforts, the work around for entity references was incomplete. This will allow XML entities to contain DTD entity references.

It is a small fix, and I plan to merge it by friday. Comments and reviews wellcome.