### PR TITLE
configure.php: recover failed XIncludes inside classsynopsis

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -839,6 +839,9 @@ function xinclude_residual_fixup( DOMDocument $dom )
             case "variablelist":
                 $fixup = "<varlistentry><term></term><listitem><simpara>$alert</simpara></listitem></varlistentry>";
                 break;
+            case "classsynopsis":
+                $fixup = "<classsynopsisinfo role=\"comment\">$alert</classsynopsisinfo>";
+                break;
             default:
                 echo "  (Unknown parent of failed XInclude: $parent)\n";
                 $hardfail = true;

--- a/configure.php
+++ b/configure.php
@@ -840,7 +840,7 @@ function xinclude_residual_fixup( DOMDocument $dom )
                 $fixup = "<varlistentry><term></term><listitem><simpara>$alert</simpara></listitem></varlistentry>";
                 break;
             case "classsynopsis":
-                $fixup = "<classsynopsisinfo role=\"comment\">$alert</classsynopsisinfo>";
+                $fixup = "<classsynopsisinfo role='comment'>$alert</classsynopsisinfo>";
                 break;
             default:
                 echo "  (Unknown parent of failed XInclude: $parent)\n";


### PR DESCRIPTION
`xinclude_residual_fixup()` recovers failed XIncludes on translations per
parent element, but had no `classsynopsis` case, so a failed include targeting
a `methodsynopsis` or `fieldsynopsis` inside a class synopsis hard-failed the
build (`Unknown parent of failed XInclude: classsynopsis`).

Adds a `classsynopsis` case injecting a `<classsynopsisinfo role="comment">`
marker, a valid child per the DocBook 5.2 RNG.

Related:
- php/doc-en#5699 removes empty `<xi:fallback/>` that masked such failures
- php/doc-en#5700 the Imagick fix whose failure first hit this path

@alfsb 
