### PR TITLE
Add --with-jing option and exercise both validators in CI

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -58,5 +58,8 @@ jobs:
           php doc-base/scripts/qa/extensions.xml.php --check
           php doc-base/scripts/qa/section-order.php
 
-      - name: "Build documentation for ${{ matrix.language }}"
-        run: "php doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"
+      - name: "Build documentation for ${{ matrix.language }} (jing)"
+        run: "php doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-jing=yes --with-lang=${{ matrix.language }}"
+
+      - name: "Build documentation for ${{ matrix.language }} (libxml)"
+        run: "php doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-jing=no --with-lang=${{ matrix.language }}"

--- a/configure.php
+++ b/configure.php
@@ -85,6 +85,8 @@ Package-specific:
   --with-php=PATH                Path to php CLI executable [detect]
   --with-lang=LANG               Language to build [{$acd['LANG']}]
   --with-partial=my-xml-id       Root ID to build (e.g. <book xml:id="MY-ID">) [{$acd['PARTIAL']}]
+  --with-jing=auto|yes|no        Validate with Jing (requires Java) instead of
+                                 libxml [{$acd['JING']}]
   --disable-broken-file-listing  Do not ignore translated files in
                                  broken-files.txt
   --disable-xpointer-reporting   Do not show XInclude/XPointer failures. Only effective
@@ -294,6 +296,7 @@ $acd = array( // {{{
     'TRANSLATION_ONLY_INCL_BEGIN' => '',
     'TRANSLATION_ONLY_INCL_END' => '',
     'XPOINTER_REPORTING' => 'yes',
+    'JING' => 'auto',
 ); // }}}
 
 $ac = $acd;
@@ -423,6 +426,14 @@ foreach ($_SERVER['argv'] as $k => $opt) { // {{{
 
         case 'xpointer-reporting':
             $ac['XPOINTER_REPORTING'] = $v;
+            break;
+
+        case 'jing':
+            if (!in_array($v, ['auto', 'yes', 'no'], true)) {
+                errbox("Invalid value for --with-jing: $v (expected auto, yes or no)");
+                errors_are_bad(1);
+            }
+            $ac['JING'] = $v;
             break;
 
         case '':
@@ -989,11 +1000,15 @@ function xml_validate( $dom )
 
     // Jing is faster, but depends on Java.
 
-    $out = null;
-    $ret = null;
-    exec( "java -version 2>&1" , $out , $ret );
+    $jing = $GLOBALS['ac']['JING'];
 
-    if ( $ret == 0 )
+    if ( $jing === 'auto' )
+    {
+        exec( "java -version 2>&1" , $out , $ret );
+        $jing = $ret === 0 ? 'yes' : 'no';
+    }
+
+    if ( $jing === 'yes' )
         xml_validate_jing();
     else
         xml_validate_libxml( $dom );
@@ -1006,16 +1021,11 @@ function xml_validate_jing()
 
     echo "Validating temp/manual.xml (jing)... ";
 
-    $out = null;
-    $ret = null;
     $schema = RNG_SCHEMA_FILE;
     $cmdJing = "java -Djdk.xml.totalEntitySizeLimit=300000 -jar {$srcdir}/docbook/jing.jar {$schema} {$idempath}";
     exec( $cmdJing , $out , $ret );
 
-    if ( ! is_array( $out ) )
-        $out = [];
-
-    if ( $ret == 0 )
+    if ( $ret === 0 )
     {
         echo "done.\n";
         return;


### PR DESCRIPTION
Server build process doesn't use `jing` for XML validation. Which is related to why doc-it https://github.com/php/doc-base/issues/327 is unable to build.

This is a first step towards fixing it by making sure we have a correct CI pipeline that build with and without `jing`.

CI is expected to fail for doc-it with the message below:

```
Failed XIncludes, manual parts will be missing. Unresolved xpointers:
- bcmath-number.round..parameters.mode
Dumped file: temp/manual.err. Inspect residual xi:include tags in this file.

Validating temp/manual.xml (libxml)... failed.

[error manual.xml 31350:0] IDREF attribute linkend references an unknown ID "language.types.void.casting"
[error manual.xml 31460:0] IDREF attribute linkend references an unknown ID "language.types.void.casting"
[error manual.xml 1319249:0] IDREF attribute linkend references an unknown ID "ini.fatal-error-backtraces"

Eyh man. No worries. Happ shittens. Try again after fixing the errors above.
```